### PR TITLE
Don't put space after readline completions

### DIFF
--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -92,6 +92,7 @@ namespace
     else
     {
       const std::string str = text_ + *pos;
+      // readline expects the string to be allocated by malloc
       char* s = (char*)malloc(str.length() + 1);
       std::copy(str.begin(), str.end(), array_begin(s, str.length() + 1));
       s[str.length()] = 0;

--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -24,6 +24,7 @@
 #  include <readline/history.h>
 #endif
 
+#include <iostream>
 #include <cassert>
 #include <algorithm>
 
@@ -91,7 +92,7 @@ namespace
     else
     {
       const std::string str = text_ + *pos;
-      char* s = new char[str.length() + 1];
+      char* s = (char*)malloc(str.length() + 1);
       std::copy(str.begin(), str.end(), array_begin(s, str.length() + 1));
       s[str.length()] = 0;
       ++pos;

--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -24,7 +24,6 @@
 #  include <readline/history.h>
 #endif
 
-#include <iostream>
 #include <cassert>
 #include <algorithm>
 

--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -86,7 +86,7 @@ namespace
 
     if (pos == values.end())
     {
-      return 0;
+      return nullptr;
     }
     else
     {
@@ -97,7 +97,7 @@ namespace
       ++pos;
       return s;
     }
-    return 0;
+    return nullptr;
   }
 
   char** tab_completion(const char* text_, int, int end_)

--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -114,6 +114,7 @@ namespace
   {
     processor_queue = &processor_queue_;
     rl_attempted_completion_function = tab_completion;
+    rl_completion_append_character = '\0';
 
     if (char *line = ::readline(prompt_.c_str()))
     {


### PR DESCRIPTION
\+ a few cosmetics.

This behaviour could be made smarter by for example adding slashes after directory completions. This is good enough for now.