### PR TITLE
File section

### DIFF
--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -19,6 +19,7 @@
 
 #include <metashell/iface/displayer.hpp>
 #include <metashell/iface/console.hpp>
+#include <metashell/data/file_location.hpp>
 
 namespace metashell
 {

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -39,6 +39,9 @@ namespace metashell
     virtual void show_cpp_code(const std::string& code_) override;
 
     virtual void show_frame(const data::frame& frame_) override;
+    virtual void show_file_section(
+      const data::file_location& location_,
+      const std::string& env_buffer_) override;
     virtual void show_backtrace(const data::backtrace& trace_) override;
     virtual void show_call_graph(const iface::call_graph& cg_) override;
   private:

--- a/include/metashell/get_file_section.hpp
+++ b/include/metashell/get_file_section.hpp
@@ -1,6 +1,22 @@
 #ifndef METASHELL_GET_FILE_SECTION_HPP
 #define METASHELL_GET_FILE_SECTION_HPP
 
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #include <string>
 #include <vector>
 #include <istream>

--- a/include/metashell/get_file_section.hpp
+++ b/include/metashell/get_file_section.hpp
@@ -19,6 +19,9 @@ using file_section = std::vector<indexed_line>;
 file_section get_file_section(
   std::istream& stream, int middle_line, int offset);
 
+file_section get_file_section_from_file(
+  const std::string& file_name, int middle_line, int offset);
+
 } // namespace metashell
 
 #endif

--- a/include/metashell/get_file_section.hpp
+++ b/include/metashell/get_file_section.hpp
@@ -1,0 +1,24 @@
+#ifndef METASHELL_GET_FILE_SECTION_HPP
+#define METASHELL_GET_FILE_SECTION_HPP
+
+#include <string>
+#include <vector>
+#include <istream>
+
+namespace metashell {
+
+struct indexed_line {
+  int line_index;
+  std::string line;
+};
+
+using file_section = std::vector<indexed_line>;
+
+// If there are enough lines in the stream, this will return that line and
+// +/- offset lines before and after that line
+file_section get_file_section(
+  std::istream& stream, int middle_line, int offset);
+
+} // namespace metashell
+
+#endif

--- a/include/metashell/get_file_section.hpp
+++ b/include/metashell/get_file_section.hpp
@@ -22,6 +22,9 @@ file_section get_file_section(
 file_section get_file_section_from_file(
   const std::string& file_name, int middle_line, int offset);
 
+file_section get_file_section_from_buffer(
+  const std::string& buffer, int middle_line, int offset);
+
 } // namespace metashell
 
 #endif

--- a/include/metashell/iface/displayer.hpp
+++ b/include/metashell/iface/displayer.hpp
@@ -21,6 +21,7 @@
 #include <metashell/data/backtrace.hpp>
 #include <metashell/data/frame.hpp>
 #include <metashell/data/type.hpp>
+#include <metashell/data/file_location.hpp>
 #include <metashell/data/type_or_error.hpp>
 
 #include <metashell/iface/call_graph.hpp>
@@ -43,6 +44,9 @@ namespace metashell
       virtual void show_cpp_code(const std::string& code_) = 0;
 
       virtual void show_frame(const data::frame& frame_) = 0;
+      virtual void show_file_section(
+        const data::file_location& location_,
+        const std::string& env_buffer_) = 0;
       virtual void show_backtrace(const data::backtrace& trace_) = 0;
       virtual void show_call_graph(const iface::call_graph& cg_) = 0;
 

--- a/include/metashell/in_memory_displayer.hpp
+++ b/include/metashell/in_memory_displayer.hpp
@@ -35,6 +35,9 @@ namespace metashell
     virtual void show_cpp_code(const std::string& code_) override;
 
     virtual void show_backtrace(const data::backtrace& trace_) override;
+    virtual void show_file_section(
+      const data::file_location& location_,
+      const std::string& env_buffer_) override;
     virtual void show_frame(const data::frame& frame_) override;
     virtual void show_call_graph(const iface::call_graph& cg_) override;
 
@@ -45,6 +48,7 @@ namespace metashell
     const std::vector<std::string>& cpp_codes() const;
 
     const std::vector<data::frame>& frames() const;
+    const std::vector<data::file_location>& file_locations() const;
     const std::vector<data::backtrace>& backtraces() const;
     const std::vector<call_graph>& call_graphs() const;
 
@@ -57,6 +61,7 @@ namespace metashell
     std::vector<data::text> _comments;
     std::vector<std::string> _cpp_codes;
     std::vector<data::frame> _frames;
+    std::vector<data::file_location> _file_locations;
     std::vector<data::backtrace> _backtraces;
     std::vector<call_graph> _call_graphs;
   };

--- a/include/metashell/json_displayer.hpp
+++ b/include/metashell/json_displayer.hpp
@@ -34,6 +34,9 @@ namespace metashell
     virtual void show_cpp_code(const std::string& code_) override;
 
     virtual void show_frame(const data::frame& frame_) override;
+    virtual void show_file_section(
+      const data::file_location& location_,
+      const std::string& env_buffer_) override;
     virtual void show_backtrace(const data::backtrace& trace_) override;
     virtual void show_call_graph(const iface::call_graph& cg_) override;
   private:

--- a/include/metashell/null_displayer.hpp
+++ b/include/metashell/null_displayer.hpp
@@ -31,6 +31,9 @@ namespace metashell
     virtual void show_cpp_code(const std::string& code_) override;
 
     virtual void show_frame(const data::frame& frame_) override;
+    virtual void show_file_section(
+      const data::file_location& location_,
+      const std::string& env_buffer_) override;
     virtual void show_backtrace(const data::backtrace& trace_) override;
     virtual void show_call_graph(const iface::call_graph& cg_) override;
   };

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -64,14 +64,8 @@ namespace
       console_.new_line();
       return;
     }
-    std::ifstream in(fl_.name);
-    if (!in) {
-      console_.show("File section not avaliable. (Can't open file)");
-      console_.new_line();
-      return;
-    }
 
-    file_section section = get_file_section(in, fl_.row, 2);
+    file_section section = get_file_section_from_file(fl_.name, fl_.row, 2);
 
     for (const auto& indexed_line : section) {
 

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <sstream>
 #include <fstream>
+#include <iomanip>
 
 using namespace metashell;
 
@@ -197,13 +198,20 @@ void console_displayer::show_file_section(
     section = get_file_section_from_file(location_.name, location_.row, 2);
   }
 
+  if (section.empty()) {
+    return;
+  }
+
+  int largest_index_length = std::to_string(section.back().line_index).size();
+
   for (const auto& indexed_line : section) {
     std::stringstream ss;
     if (indexed_line.line_index == location_.row) {
-      ss << "-> ";
+      ss << "->";
     } else {
-      ss << "   ";
+      ss << "  ";
     }
+    ss << std::setw(largest_index_length + 1);
     ss << indexed_line.line_index << "  " << indexed_line.line;
 
     _console->show(ss.str());

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -18,6 +18,7 @@
 #include <metashell/data/colored_string.hpp>
 #include <metashell/highlight_syntax.hpp>
 #include <metashell/indenter.hpp>
+#include <metashell/get_file_section.hpp>
 
 #include <mindent/stream_display.hpp>
 #include <mindent/display.hpp>
@@ -70,42 +71,17 @@ namespace
       return;
     }
 
-    auto line_number = fl_.row;
-    if (line_number <= 0) {
-      console_.show("File section not avaliable. (Invalid line number)");
-      console_.new_line();
-      return;
-    }
+    file_section section = get_file_section(in, fl_.row, 2);
 
-    std::vector<std::tuple<int, std::string>> lines;
-
-    std::string line;
-    for (int i = 1; std::getline(in, line); ++i) {
-      if (i < line_number - 2) {
-        continue;
-      }
-      if (i > line_number + 2) {
-        break;
-      }
-      lines.push_back(std::make_tuple(i, line));
-    }
-    if (lines.empty()) {
-      console_.show("File section not avaliable. (Not enough lines in file)");
-      console_.new_line();
-      return;
-    }
-    for (const auto& indexed_line : lines) {
-      int line_index;
-      std::string line;
-      std::tie(line_index, line) = indexed_line;
+    for (const auto& indexed_line : section) {
 
       std::stringstream ss;
-      if (line_index == line_number) {
-        ss << " -> ";
+      if (indexed_line.line_index == fl_.row) {
+        ss << "-> ";
       } else {
-        ss << "    ";
+        ss << "   ";
       }
-      ss << line_index << "    " << line;
+      ss << indexed_line.line_index << "  " << indexed_line.line;
 
       console_.show(ss.str());
       console_.new_line();

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -53,34 +53,6 @@ namespace
       f_
     );
   }
-
-  void display_file_section(
-    const data::file_location& fl_,
-    iface::console& console_)
-  {
-    if (fl_.name == "<stdin>") {
-      // TODO
-      console_.show("line form <stdin>");
-      console_.new_line();
-      return;
-    }
-
-    file_section section = get_file_section_from_file(fl_.name, fl_.row, 2);
-
-    for (const auto& indexed_line : section) {
-
-      std::stringstream ss;
-      if (indexed_line.line_index == fl_.row) {
-        ss << "-> ";
-      } else {
-        ss << "   ";
-      }
-      ss << indexed_line.line_index << "  " << indexed_line.line;
-
-      console_.show(ss.str());
-      console_.new_line();
-    }
-  }
 }
 
 console_displayer::console_displayer(
@@ -212,7 +184,31 @@ void console_displayer::show_frame(const data::frame& frame_)
     _console->show(s.str());
   }
   _console->new_line();
-  display_file_section(frame_.point_of_instantiation(), *_console);
+}
+
+void console_displayer::show_file_section(
+  const data::file_location& location_,
+  const std::string& env_buffer_)
+{
+  file_section section;
+  if (location_.name == "<stdin>") {
+    section = get_file_section_from_buffer(env_buffer_, location_.row, 2);
+  } else {
+    section = get_file_section_from_file(location_.name, location_.row, 2);
+  }
+
+  for (const auto& indexed_line : section) {
+    std::stringstream ss;
+    if (indexed_line.line_index == location_.row) {
+      ss << "-> ";
+    } else {
+      ss << "   ";
+    }
+    ss << indexed_line.line_index << "  " << indexed_line.line;
+
+    _console->show(ss.str());
+    _console->new_line();
+  }
 }
 
 void console_displayer::show_backtrace(const data::backtrace& trace_)

--- a/lib/core/get_file_section.cpp
+++ b/lib/core/get_file_section.cpp
@@ -1,3 +1,19 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #include <metashell/get_file_section.hpp>
 
 #include <fstream>

--- a/lib/core/get_file_section.cpp
+++ b/lib/core/get_file_section.cpp
@@ -1,0 +1,23 @@
+#include <metashell/get_file_section.hpp>
+
+namespace metashell {
+
+file_section get_file_section(
+  std::istream& stream, int middle_line, int offset)
+{
+  file_section result;
+
+  std::string line;
+  for (int i = 1; std::getline(stream, line); ++i) {
+    if (i > middle_line + offset) {
+      break;
+    }
+    if (i < middle_line - offset) {
+      continue;
+    }
+    result.push_back({i, line});
+  }
+  return result;
+}
+
+} // namespace metashell

--- a/lib/core/get_file_section.cpp
+++ b/lib/core/get_file_section.cpp
@@ -11,7 +11,8 @@ file_section get_file_section(
   file_section result;
 
   std::string line;
-  for (int i = 1; std::getline(stream, line); ++i) {
+  int i = 1;
+  for (; std::getline(stream, line); ++i) {
     if (i > middle_line + offset) {
       break;
     }
@@ -19,6 +20,9 @@ file_section get_file_section(
       continue;
     }
     result.push_back({i, line});
+  }
+  if (i-1 < middle_line) {
+    return {};
   }
   return result;
 }

--- a/lib/core/get_file_section.cpp
+++ b/lib/core/get_file_section.cpp
@@ -24,6 +24,10 @@ namespace metashell {
 file_section get_file_section(
   std::istream& stream, int middle_line, int offset)
 {
+  if (middle_line <= 0 || offset < 0) {
+    return {};
+  }
+
   file_section result;
 
   std::string line;

--- a/lib/core/get_file_section.cpp
+++ b/lib/core/get_file_section.cpp
@@ -1,6 +1,7 @@
 #include <metashell/get_file_section.hpp>
 
 #include <fstream>
+#include <sstream>
 
 namespace metashell {
 
@@ -30,6 +31,13 @@ file_section get_file_section_from_file(
     return {};
   }
   return get_file_section(in, middle_line, offset);
+}
+
+file_section get_file_section_from_buffer(
+  const std::string& buffer, int middle_line, int offset)
+{
+  std::stringstream ss(buffer);
+  return get_file_section(ss, middle_line, offset);
 }
 
 } // namespace metashell

--- a/lib/core/get_file_section.cpp
+++ b/lib/core/get_file_section.cpp
@@ -1,5 +1,7 @@
 #include <metashell/get_file_section.hpp>
 
+#include <fstream>
+
 namespace metashell {
 
 file_section get_file_section(
@@ -18,6 +20,16 @@ file_section get_file_section(
     result.push_back({i, line});
   }
   return result;
+}
+
+file_section get_file_section_from_file(
+  const std::string& file_name, int middle_line, int offset)
+{
+  std::ifstream in(file_name);
+  if (!in) {
+    return {};
+  }
+  return get_file_section(in, middle_line, offset);
 }
 
 } // namespace metashell

--- a/lib/core/in_memory_displayer.cpp
+++ b/lib/core/in_memory_displayer.cpp
@@ -48,6 +48,13 @@ void in_memory_displayer::show_frame(const data::frame& frame_)
   _frames.push_back(frame_);
 }
 
+void in_memory_displayer::show_file_section(
+  const data::file_location& location_,
+  const std::string& /*env_buffer_*/)
+{
+  _file_locations.push_back(location_);
+}
+
 void in_memory_displayer::show_backtrace(const data::backtrace& trace_)
 {
   _backtraces.push_back(trace_);
@@ -88,6 +95,12 @@ const std::vector<data::frame>& in_memory_displayer::frames() const
   return _frames;
 }
 
+const std::vector<data::file_location>&
+in_memory_displayer::file_locations() const
+{
+  return _file_locations;
+}
+
 const std::vector<data::backtrace>& in_memory_displayer::backtraces() const
 {
   return _backtraces;
@@ -107,6 +120,7 @@ void in_memory_displayer::clear()
   _comments.clear();
   _cpp_codes.clear();
   _frames.clear();
+  _file_locations.clear();
   _backtraces.clear();
   _call_graphs.clear();
 }

--- a/lib/core/json_displayer.cpp
+++ b/lib/core/json_displayer.cpp
@@ -125,8 +125,8 @@ void json_displayer::show_frame(const data::frame& frame_)
 }
 
 void json_displayer::show_file_section(
-  const data::file_location& location_,
-  const std::string& env_buffer_)
+  const data::file_location& /*location_*/,
+  const std::string& /*env_buffer_*/)
 {
   // We don't show this in json. Whoever uses the json interface can do it
   // himself the way he wants it

--- a/lib/core/json_displayer.cpp
+++ b/lib/core/json_displayer.cpp
@@ -124,6 +124,14 @@ void json_displayer::show_frame(const data::frame& frame_)
   _writer.end_document();
 }
 
+void json_displayer::show_file_section(
+  const data::file_location& location_,
+  const std::string& env_buffer_)
+{
+  // We don't show this in json. Whoever uses the json interface can do it
+  // himself the way he wants it
+}
+
 void json_displayer::show_backtrace(const data::backtrace& trace_)
 {
   _writer.start_object();

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -910,7 +910,13 @@ void mdb_shell::display_current_frame(iface::displayer& displayer_) const {
   auto frame = mp->get_current_frame();
   displayer_.show_frame(frame);
   if (frame.is_full()) {
-    displayer_.show_file_section(frame.point_of_instantiation(), env.get());
+    // TODO: we should somehow compensate the file_locations returned by
+    // clang for the <stdin> file. This is hard because the file clang sees
+    // is just two lines (an include for the PCH and the current line)
+    // Until this is figured out, printing file sections for <stdin> is
+    // turned off
+    // displayer_.show_file_section(frame.point_of_instantiation(), env.get());
+    displayer_.show_file_section(frame.point_of_instantiation(), "");
   }
 }
 

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -910,7 +910,7 @@ void mdb_shell::display_current_frame(iface::displayer& displayer_) const {
   auto frame = mp->get_current_frame();
   displayer_.show_frame(frame);
   if (frame.is_full()) {
-    displayer_.show_file_section(frame.point_of_instantiation(), env.get_all());
+    displayer_.show_file_section(frame.point_of_instantiation(), env.get());
   }
 }
 

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -907,7 +907,11 @@ void mdb_shell::display_current_frame(iface::displayer& displayer_) const {
   assert(!mp->is_at_start());
   assert(!mp->is_finished());
 
-  displayer_.show_frame(mp->get_current_frame());
+  auto frame = mp->get_current_frame();
+  displayer_.show_frame(frame);
+  if (frame.is_full()) {
+    displayer_.show_file_section(frame.point_of_instantiation(), env.get_all());
+  }
 }
 
 void mdb_shell::display_current_forwardtrace(

--- a/lib/core/null_displayer.cpp
+++ b/lib/core/null_displayer.cpp
@@ -48,6 +48,12 @@ void null_displayer::show_frame(const data::frame&)
   // throw away
 }
 
+void null_displayer::show_file_section(
+  const data::file_location&, const std::string&)
+{
+  // throw away
+}
+
 void null_displayer::show_backtrace(const data::backtrace&)
 {
   // throw away

--- a/test/unit/test_get_file_section.cpp
+++ b/test/unit/test_get_file_section.cpp
@@ -1,0 +1,133 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell/get_file_section.hpp>
+
+#include <just/test.hpp>
+
+using namespace metashell;
+
+void indexed_line_assert_equal(const indexed_line& a, const indexed_line& b) {
+  JUST_ASSERT_EQUAL(a.line_index, b.line_index);
+  JUST_ASSERT_EQUAL(a.line, b.line);
+}
+
+JUST_TEST_CASE(test_get_file_section_empty) {
+  std::string buffer = "";
+
+  auto section = get_file_section_from_buffer(buffer, 3, 2);
+
+  JUST_ASSERT_EQUAL(0u, section.size());
+}
+
+JUST_TEST_CASE(test_get_file_section_one_line) {
+  std::string buffer = "the first line\n";
+
+  auto section = get_file_section_from_buffer(buffer, 1, 2);
+
+  JUST_ASSERT_EQUAL(1u, section.size());
+  indexed_line_assert_equal({1, "the first line"}, section[0]);
+}
+
+JUST_TEST_CASE(test_get_file_section_one_line_out_of_bounds) {
+  std::string buffer = "the first line\n";
+
+  auto section = get_file_section_from_buffer(buffer, 2, 2);
+
+  JUST_ASSERT_EQUAL(0u, section.size());
+}
+
+JUST_TEST_CASE(test_get_file_section_one_line_out_of_bounds_zero) {
+  std::string buffer = "the first line\n";
+
+  auto section = get_file_section_from_buffer(buffer, 0, 2);
+
+  JUST_ASSERT_EQUAL(0u, section.size());
+}
+
+JUST_TEST_CASE(test_get_file_section_two_line_1) {
+  std::string buffer = "the first line\nthe second line\n";
+
+  auto section = get_file_section_from_buffer(buffer, 1, 2);
+
+  JUST_ASSERT_EQUAL(2u, section.size());
+  indexed_line_assert_equal({1, "the first line"}, section[0]);
+  indexed_line_assert_equal({2, "the second line"}, section[1]);
+}
+
+JUST_TEST_CASE(test_get_file_section_two_lines_2) {
+  std::string buffer = "the first line\nthe second line\n";
+
+  auto section = get_file_section_from_buffer(buffer, 2, 2);
+
+  JUST_ASSERT_EQUAL(2u, section.size());
+  indexed_line_assert_equal({1, "the first line"}, section[0]);
+  indexed_line_assert_equal({2, "the second line"}, section[1]);
+}
+
+JUST_TEST_CASE(test_get_file_section_six_lines_1) {
+  std::string buffer =
+    "the first line\nthe second line\nthird\n4\nfifth\n6";
+
+  auto section = get_file_section_from_buffer(buffer, 2, 2);
+
+  JUST_ASSERT_EQUAL(4u, section.size());
+  indexed_line_assert_equal({1, "the first line"}, section[0]);
+  indexed_line_assert_equal({2, "the second line"}, section[1]);
+  indexed_line_assert_equal({3, "third"}, section[2]);
+  indexed_line_assert_equal({4, "4"}, section[3]);
+}
+
+JUST_TEST_CASE(test_get_file_section_six_lines_2) {
+  std::string buffer =
+    "the first line\nthe second line\nthird\n4\nfifth\n6";
+
+  auto section = get_file_section_from_buffer(buffer, 3, 2);
+
+  JUST_ASSERT_EQUAL(5u, section.size());
+  indexed_line_assert_equal({1, "the first line"}, section[0]);
+  indexed_line_assert_equal({2, "the second line"}, section[1]);
+  indexed_line_assert_equal({3, "third"}, section[2]);
+  indexed_line_assert_equal({4, "4"}, section[3]);
+  indexed_line_assert_equal({5, "fifth"}, section[4]);
+}
+
+JUST_TEST_CASE(test_get_file_section_six_lines_3) {
+  std::string buffer =
+    "the first line\nthe second line\nthird\n4\nfifth\n6";
+
+  auto section = get_file_section_from_buffer(buffer, 4, 2);
+
+  JUST_ASSERT_EQUAL(5u, section.size());
+  indexed_line_assert_equal({2, "the second line"}, section[0]);
+  indexed_line_assert_equal({3, "third"}, section[1]);
+  indexed_line_assert_equal({4, "4"}, section[2]);
+  indexed_line_assert_equal({5, "fifth"}, section[3]);
+  indexed_line_assert_equal({6, "6"}, section[4]);
+}
+
+JUST_TEST_CASE(test_get_file_section_six_lines_4) {
+  std::string buffer =
+    "the first line\nthe second line\nthird\n4\nfifth\n6";
+
+  auto section = get_file_section_from_buffer(buffer, 5, 2);
+
+  JUST_ASSERT_EQUAL(4u, section.size());
+  indexed_line_assert_equal({3, "third"}, section[0]);
+  indexed_line_assert_equal({4, "4"}, section[1]);
+  indexed_line_assert_equal({5, "fifth"}, section[2]);
+  indexed_line_assert_equal({6, "6"}, section[3]);
+}


### PR DESCRIPTION
Produces this kind of output when movement commands are used in mdb:
```
(mdb) s
boost::mpl::aux::sequence_tag_impl<true, false> (Memoization from /usr/local/include/boost/mpl/sequence_tag.hpp:111:12)
   109      >
   110  struct sequence_tag
-> 111      : aux::sequence_tag_impl<
   112            ::boost::mpl::aux::has_tag<Sequence>::value
   113          , ::boost::mpl::aux::has_begin<Sequence>::value
```

There is no such output for the <stdin> buffer as explained in a comment in the code.