### PR TITLE
Add frame command

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,7 @@
     * Optional logging of what Metashell is doing in the background.
     * New MDB command: `step out`
     * New MDB command: `next`, alias for `step over`
+    * New MDB command: `frame`
     * MDB now can debug metaprograms which fail to compile
     * MDB now prints the relevant sections of the source code for movement
       commands

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -8,6 +8,8 @@
     * New MDB command: `step out`
     * New MDB command: `next`, alias for `step over`
     * MDB now can debug metaprograms which fail to compile
+    * MDB now prints the relevant sections of the source code for movement
+      commands
     * Significantly improved MDB performance for large metaprograms
     * New command-line arguments:
         * `--console` for choosing shell mode

--- a/docs/reference/mdb_commands.md
+++ b/docs/reference/mdb_commands.md
@@ -58,7 +58,7 @@ The n specifier limits the depth of the trace. If n is not specified, then the
 * __`backtrace|bt `__ <br />
 Print backtrace from the current point.
 
-* __`frame|f `__ <br />
+* __`frame|f n `__ <br />
 Print the nth frame from the current point.
 
 * __`help [<command>]`__ <br />

--- a/docs/reference/mdb_commands.md
+++ b/docs/reference/mdb_commands.md
@@ -58,6 +58,9 @@ The n specifier limits the depth of the trace. If n is not specified, then the
 * __`backtrace|bt `__ <br />
 Print backtrace from the current point.
 
+* __`frame|f `__ <br />
+Print the nth frame from the current point.
+
 * __`help [<command>]`__ <br />
 Show help for commands. <br />
 If <command> is not specified, show a list of all available commands.

--- a/docs/reference/mdb_commands.md
+++ b/docs/reference/mdb_commands.md
@@ -58,7 +58,7 @@ The n specifier limits the depth of the trace. If n is not specified, then the
 * __`backtrace|bt `__ <br />
 Print backtrace from the current point.
 
-* __`frame|f n `__ <br />
+* __`frame|f n`__ <br />
 Print the nth frame from the current point.
 
 * __`help [<command>]`__ <br />

--- a/include/metashell/data/backtrace.hpp
+++ b/include/metashell/data/backtrace.hpp
@@ -31,6 +31,7 @@ namespace metashell
     class backtrace : boost::equality_comparable<backtrace>
     {
     public:
+      typedef std::vector<frame>::size_type size_type;
       typedef std::vector<frame>::const_iterator iterator;
       typedef iterator const_iterator;
 
@@ -39,6 +40,9 @@ namespace metashell
       backtrace(const std::initializer_list<frame>& frames_);
 
       void push_back(const frame& f_);
+
+      size_type size() const;
+      const frame& operator[](size_type i) const;
 
       iterator begin() const;
       iterator end() const;

--- a/include/metashell/mdb_shell.hpp
+++ b/include/metashell/mdb_shell.hpp
@@ -65,6 +65,7 @@ public:
     iface::displayer& displayer_
   );
   void command_backtrace(const std::string& arg, iface::displayer& displayer_);
+  void command_frame(const std::string& arg, iface::displayer& displayer_);
   void command_rbreak(const std::string& arg, iface::displayer& displayer_);
   void command_help(const std::string& arg, iface::displayer& displayer_);
   void command_quit(const std::string& arg, iface::displayer& displayer_);
@@ -109,13 +110,17 @@ protected:
   void filter_similar_edges();
   void filter_metaprogram();
 
-  static
-  boost::optional<int> parse_single_integer_arg(const std::string& arg);
+  static boost::optional<int> parse_defaultable_integer(
+    const std::string& arg, int default_value);
+
+  static boost::optional<int> parse_mandatory_integer(const std::string& arg);
 
   breakpoints_t::iterator continue_metaprogram(direction_t direction);
 
   void next_metaprogram(direction_t direction, int n);
 
+  void display_frame(
+    const data::frame& frame, iface::displayer& displayer_) const;
   void display_current_frame(iface::displayer& displayer_) const;
   void display_current_forwardtrace(
     boost::optional<int> max_depth,

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -960,10 +960,6 @@ void mdb_shell::next_metaprogram(direction_t direction, int n) {
 void mdb_shell::display_frame(
   const data::frame& frame, iface::displayer& displayer_) const
 {
-  assert(mp);
-  assert(!mp->is_at_start());
-  assert(!mp->is_finished());
-
   displayer_.show_frame(frame);
   if (frame.is_full()) {
     // TODO: we should somehow compensate the file_locations returned by
@@ -977,6 +973,10 @@ void mdb_shell::display_frame(
 }
 
 void mdb_shell::display_current_frame(iface::displayer& displayer_) const {
+  assert(mp);
+  assert(!mp->is_at_start());
+  assert(!mp->is_finished());
+
   display_frame(mp->get_current_frame(), displayer_);
 }
 

--- a/lib/data/backtrace.cpp
+++ b/lib/data/backtrace.cpp
@@ -29,6 +29,16 @@ void backtrace::push_back(const frame& f_)
   _frames.push_back(f_);
 }
 
+backtrace::size_type backtrace::size() const
+{
+  return _frames.size();
+}
+
+const frame& backtrace::operator[](size_type i) const
+{
+  return _frames[i];
+}
+
 backtrace::iterator backtrace::begin() const
 {
   return _frames.begin();

--- a/test/system/app/mdb/test_frame.cpp
+++ b/test/system/app/mdb/test_frame.cpp
@@ -1,0 +1,179 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell_system_test/type.hpp>
+#include <metashell_system_test/error.hpp>
+#include <metashell_system_test/frame.hpp>
+#include <metashell_system_test/prompt.hpp>
+#include <metashell_system_test/raw_text.hpp>
+#include <metashell_system_test/run_metashell.hpp>
+#include <metashell_system_test/json_generator.hpp>
+
+#include "test_metaprograms.hpp"
+
+#include <just/test.hpp>
+
+using namespace metashell_system_test;
+
+JUST_TEST_CASE(test_mdb_frame_without_evaluation) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb"),
+        command("frame")
+      }
+    );
+
+  auto i = r.begin() + 2;
+
+  JUST_ASSERT_EQUAL(error("Metaprogram not evaluated yet"), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_before_starting) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb int"),
+        command("frame 0")
+      }
+    );
+
+  auto i = r.begin() + 3;
+
+  JUST_ASSERT_EQUAL(frame(type("int")), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_step_1) {
+  const auto r =
+    run_metashell(
+      {
+        command(fibonacci_mp),
+        command("#msh mdb int_<fib<10>::value>"),
+        command("step"),
+        command("frame 0"),
+        command("frame 1")
+      }
+    );
+
+  auto i = r.begin() + 6;
+
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<10>"), instantiation_kind::template_instantiation), *i);
+
+  i += 2;
+
+  JUST_ASSERT_EQUAL(frame(type("int_<fib<10>::value>")), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_step_2) {
+  const auto r =
+    run_metashell(
+      {
+        command(fibonacci_mp),
+        command("#msh mdb int_<fib<10>::value>"),
+        command("step 2"),
+        command("frame 0"),
+        command("frame 1"),
+        command("frame 2")
+      }
+    );
+
+  auto i = r.begin() + 6;
+
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<8>"), instantiation_kind::template_instantiation), *i);
+
+  i += 2;
+
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<10>"), instantiation_kind::template_instantiation), *i);
+
+  i += 2;
+
+  JUST_ASSERT_EQUAL(frame(type("int_<fib<10>::value>")), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_at_end) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb int"),
+        command("continue"),
+        command("frame 0")
+      }
+    );
+
+  auto i = r.begin() + 6;
+
+  JUST_ASSERT_EQUAL(raw_text("Metaprogram finished"), *i++);
+  JUST_ASSERT_EQUAL(type("int"), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_no_argument) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb int"),
+        command("frame")
+      }
+    );
+
+  auto i = r.begin() + 3;
+
+  JUST_ASSERT_EQUAL(error("Argument parsing failed"), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_garbage_argument) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb int"),
+        command("frame asd")
+      }
+    );
+
+  auto i = r.begin() + 3;
+
+  JUST_ASSERT_EQUAL(error("Argument parsing failed"), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_out_of_range_arg_negative) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb int"),
+        command("frame -1")
+      }
+    );
+
+  auto i = r.begin() + 3;
+
+  JUST_ASSERT_EQUAL(error("Frame index out of range"), *i);
+}
+
+JUST_TEST_CASE(test_mdb_frame_fib_out_of_range_arg_too_large) {
+  const auto r =
+    run_metashell(
+      {
+        command("#msh mdb int"),
+        command("frame 1")
+      }
+    );
+
+  auto i = r.begin() + 3;
+
+  JUST_ASSERT_EQUAL(error("Frame index out of range"), *i);
+}


### PR DESCRIPTION
Add frame command to inspect backtrace frames:
```
(mdb) bt
#0 fib<7> (TemplateInstantiation from ./../fib.hpp:3:32)
#1 fib<8> (TemplateInstantiation from ./../fib.hpp:3:32)
#2 fib<9> (TemplateInstantiation from ./../fib.hpp:3:32)
#3 fib<10> (TemplateInstantiation from <stdin>:2:31)
#4 int_<fib<10>::value>
(mdb) frame 2
fib<9> (TemplateInstantiation from ./../fib.hpp:3:32)
   1  template<int N>
   2  struct fib {
-> 3    constexpr static int value = fib<N-1>::value + fib<N-2>::value;
   4  };
   5
```