### PR TITLE
Pager support and experimental profiling in MDB

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,5 +1,11 @@
 <h1>Changelog</h1>
 
+## Not in any release yet
+
+* New features
+    * Add pager for MDB commands which tend to have long output
+    * Experimental support for profiling metaprograms
+
 ## Version 2.1.0
 
 * New features

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,7 +4,8 @@
 
 * New features
     * Add pager for MDB commands which tend to have long output
-    * Experimental support for profiling metaprograms
+    * Experimental support for profiling metaprograms in MDB
+    * Experimental support for traversing the whole environment in MDB
 
 ## Version 2.1.0
 

--- a/docs/manual/embedding.md
+++ b/docs/manual/embedding.md
@@ -11,17 +11,17 @@ of the commands and the output will be structured JSON documents separated by
 
 Here is the list of commands Metashell accepts when it is running in JSON-mode.
 
-* __cmd__ <br />
-<br />
-Format: `{ "type":"cmd", "cmd":"<command>" }` <br />
-<br />
+* __cmd__
+
+Format: `{ "type":"cmd", "cmd":"<command>" }`
+
 Sending this command to Metashell means that the user has typed `<command>` in
 and pressed enter in the shell.
 
-* __code\_completion__ <br />
-<br />
-Format: `{ "type":"code_completion", "code":"<code to complete>" }` <br />
-<br />
+* __code\_completion__
+
+Format: `{ "type":"code_completion", "code":"<code to complete>" }`
+
 Sending this command to Meashell means that the user has asked for
 code-completion and the code to complete is `<code to complete>`. As a response
 to this, Metashell will display an object of type `code_completion_result`.
@@ -34,105 +34,145 @@ The order of the fields of objects is fixed to make SAX-like parsing easier.
 As in some cases (when displaying forward traces) the documents might be large,
 using SAX-like JSON parsers is recommended.
 
-* __backtrace__ <br />
-<br />
+* __backtrace__
+
 Format:
-`{ "type":"backtrace", "frames":[<frames of the backtrace>] }` <br />
-<br />
+```json
+{
+  "type":"backtrace",
+  "frames":[<frames of the backtrace>]
+}
+```
+
 Displays a template metaprogramming backtrace, which is a list of recursive
 template instantiations. Each frame in the trace is a template instatiation
 triggered by the preceeding frame. The format of the frames is the
-following: <br />
-<br />
-`{
+following:
+
+```json
+{
   "name":"<type instantiated>",
   "kind":"<kind of instatiation>"
   "point_of_instantiation":"<point of instantiation>"
-}` <br />
-<br />
+}
+```
+
 The `name`, `kind`, `point_of_instantiation` fields are the same as the fields
 of the `frame` object.
 
-* __call\_graph__ <br />
-<br />
+* __call\_graph__
+
 Format:
-`{ "type":"call_graph", "nodes":[<nodes of the call graph>] }` <br />
-<br />
+```json
+{
+  "type":"call_graph",
+  "nodes":[<nodes of the call graph>]
+}
+```
+
 Displays a template metaprogramming call graph, which is a tree (some nodes may
 appear multiple times, in which case they a separate nodes of the tree). The
 list of nodes are the nodes of the graph listed in the same order as a
 depth-first traversal starting from the root of the tree would visit them. The
-format of the nodes is the following: <br />
-<br />
-`{
+format of the nodes is the following:
+
+```json
+{
   "name":"<type instantiated>",
   "kind":"<kind of instatiation>",
   "point_of_instantiation":"<point of instantiation>"
   "depth":<depth of the node in the tree>,
   "children":<number of children the node has>
-}` <br />
-<br />
+}
+```
+
 The `name`, `kind` and `point_of_instantiation` fields are the same as the
 fields of the `frame` object. The values of the `<depth>` and `<children>`
 fields are integers.
 
-* __code\_completion\_result__ <br />
-<br />
+* __code\_completion\_result__
+
 Format:
-`{ "type":"code_completion_result", "completions":[<list of completions>] }`
-<br />
-<br />
+```json
+{
+  "type":"code_completion_result",
+  "completions":[<list of completions>]
+}
+```
+
 This is displayed as the response to a `code_completion` command. The
 `<list of completions>` is a list of strings, which are the possible completions
 of the code snippet provided in the `code_completion` command.
 
-* __comment__ <br />
-<br />
-Format: `{ "type":"comment", "paragraphs":[<list of paragraphs>] }` <br />
-<br />
+* __comment__
+
+Format:
+```json
+{
+  "type":"comment",
+  "paragraphs":[<list of paragraphs>]
+}
+```
+
 Display a C++ comment. The content of the comment is a text in paragraphs. Each
-paragraph is described by a JSON object with the following format: <br />
-<br />
-`{
+paragraph is described by a JSON object with the following format:
+
+```json
+{
   "first_line_indentation":"<characters to indent with>",
   "rest_of_lines_indentation":"<characters to indent with>",
   "content":"<text of the paragraph>"
-}` <br />
-<br />
+}
+```
+
 The displayer can add line-breaks to the text of the paragraph to fit the width
 of the display. The whitespaces (or other characters) to use for indentation are
 provided for each paragraph. The first line have a custom indentation.
 
-* __cpp\_code__ <br />
-<br />
-Format: `{ "type":"cpp_code", "code":"<C++ code>" }` <br />
-<br />
+* __cpp\_code__
+
+Format:
+```json
+{
+  "type":"cpp_code",
+  "code":"<C++ code>"
+}
+```
+
 Display a C++ code snippet.
 
-* __error__ <br />
-<br />
-Format: `{ "type":"error", "msg":"<error message>" }` <br />
-<br />
+* __error__
+
+Format:
+```json
+{
+  "type":"error",
+  "msg":"<error message>"
+}
+```
+
 An error occured. The description of the error is `<error message>`.
 
-* __frame__ <br />
-<br />
+* __frame__
+
 Format:
-`{
+```json
+{
   "type":"frame",
   "name":"<type instantiated>",
   "kind":"<kind of instatiation>"
   "point_of_instantiation":"<point of instantiation>"
   "time_taken":"<time taken in seconds>"
   "time_taken_ratio":"<time taken ratio>
-}` <br />
-<br />
+}
+```
+
 Display a template class instantiation. This is treated as a stack frame of a
 template metaprogram execution (this is where the name comes from). The
 `<type instantiated>` is the pretty-printed version of the template instance.
 The `kind`, `point_of_instantiation`, `time_taken` and `time_taken_ratio` fields
 are optional depending on whether Metashell has this information. The possible
-values for kind are: <br />
+values for kind are:
 
     * `DefaultFunctionArgumentInstantiation`
     * `DefaultTemplateArgumentChecking`
@@ -156,25 +196,44 @@ double and can be generally expected to be in the range `[0-1]`. Sometimes it
 can get out of this range, if there is something wrong with how the compiler
 reports timings to Metashell.
 
-* __prompt__ <br />
-<br />
-Format: `{ "type":"prompt", "prompt":"<prompt to display>" }` <br />
-<br />
+* __prompt__
+
+Format:
+
+```json
+{
+  "type":"prompt",
+  "prompt":"<prompt to display>"
+}
+```
+
 This means that the shell is waiting for input. The prompt to use is
 `<prompt to display>`. After displaying this command the shell will not display
 further output until the next command arrives.
 
-* __raw\_text__ <br />
-<br />
-Format: `{ "type":"raw_text", "value":"<text>" }` <br />
-<br />
+* __raw\_text__
+
+Format:
+
+```
+{
+  "type":"raw_text",
+  "value":"<text>"
+}
+```
+
 `<text>` should be displayed.
 
-* __type__ <br />
-<br />
-Format: `{ "type":"type", "name":"<pretty printed type>" }` <br />
-<br />
-Display a C++ type.
+* __type__
 
-<p>&nbsp;</p>
+Format:
+
+```
+{
+  "type":"type",
+  "name":"<pretty printed type>"
+}
+```
+
+Display a C++ type.
 

--- a/docs/manual/embedding.md
+++ b/docs/manual/embedding.md
@@ -1,4 +1,4 @@
-<h1>Embedding Metashell into other applications</h1>
+# Embedding Metashell into other applications
 
 Metashell provides a [JSON](http://json.org/)-based interface for building a
 custom front-end or embedding Metashell into IDEs. To use it, you need to start
@@ -13,14 +13,26 @@ Here is the list of commands Metashell accepts when it is running in JSON-mode.
 
 * __cmd__
 
-Format: `{ "type":"cmd", "cmd":"<command>" }`
+Format:
+```json
+{
+  "type":"cmd",
+  "cmd":"<command>"
+}
+```
 
 Sending this command to Metashell means that the user has typed `<command>` in
 and pressed enter in the shell.
 
 * __code\_completion__
 
-Format: `{ "type":"code_completion", "code":"<code to complete>" }`
+Format:
+```json
+{
+  "type":"code_completion",
+  "code":"<code to complete>"
+}
+```
 
 Sending this command to Meashell means that the user has asked for
 code-completion and the code to complete is `<code to complete>`. As a response
@@ -40,7 +52,7 @@ Format:
 ```json
 {
   "type":"backtrace",
-  "frames":[<frames of the backtrace>]
+  "frames":"[list of frames of the backtrace]"
 }
 ```
 
@@ -52,7 +64,7 @@ following:
 ```json
 {
   "name":"<type instantiated>",
-  "kind":"<kind of instatiation>"
+  "kind":"<kind of instatiation>",
   "point_of_instantiation":"<point of instantiation>"
 }
 ```
@@ -66,7 +78,7 @@ Format:
 ```json
 {
   "type":"call_graph",
-  "nodes":[<nodes of the call graph>]
+  "nodes":"[list of nodes of the call graph]"
 }
 ```
 
@@ -80,9 +92,9 @@ format of the nodes is the following:
 {
   "name":"<type instantiated>",
   "kind":"<kind of instatiation>",
-  "point_of_instantiation":"<point of instantiation>"
-  "depth":<depth of the node in the tree>,
-  "children":<number of children the node has>
+  "point_of_instantiation":"<point of instantiation>",
+  "depth":"<depth of the node in the tree>",
+  "children":"<number of children the node has>"
 }
 ```
 
@@ -96,7 +108,7 @@ Format:
 ```json
 {
   "type":"code_completion_result",
-  "completions":[<list of completions>]
+  "completions":"[list of completions]"
 }
 ```
 
@@ -110,7 +122,7 @@ Format:
 ```json
 {
   "type":"comment",
-  "paragraphs":[<list of paragraphs>]
+  "paragraphs":"[list of paragraphs]"
 }
 ```
 
@@ -160,10 +172,10 @@ Format:
 {
   "type":"frame",
   "name":"<type instantiated>",
-  "kind":"<kind of instatiation>"
-  "point_of_instantiation":"<point of instantiation>"
-  "time_taken":"<time taken in seconds>"
-  "time_taken_ratio":"<time taken ratio>
+  "kind":"<kind of instatiation>",
+  "point_of_instantiation":"<point of instantiation>",
+  "time_taken":"<time taken in seconds>",
+  "time_taken_ratio":"<time taken ratio>"
 }
 ```
 
@@ -215,7 +227,7 @@ further output until the next command arrives.
 
 Format:
 
-```
+```json
 {
   "type":"raw_text",
   "value":"<text>"
@@ -228,7 +240,7 @@ Format:
 
 Format:
 
-```
+```json
 {
   "type":"type",
   "name":"<pretty printed type>"

--- a/docs/manual/embedding.md
+++ b/docs/manual/embedding.md
@@ -123,13 +123,16 @@ Format:
   "name":"<type instantiated>",
   "kind":"<kind of instatiation>"
   "point_of_instantiation":"<point of instantiation>"
+  "time_taken":"<time taken in seconds>"
+  "time_taken_ratio":"<time taken ratio>
 }` <br />
 <br />
 Display a template class instantiation. This is treated as a stack frame of a
 template metaprogram execution (this is where the name comes from). The
 `<type instantiated>` is the pretty-printed version of the template instance.
-The `kind` and `point_of_instantiation` fields are optional depending on
-whether Metashell has this information. The possible values for kind are: <br />
+The `kind`, `point_of_instantiation`, `time_taken` and `time_taken_ratio` fields
+are optional depending on whether Metashell has this information. The possible
+values for kind are: <br />
 
     * `DefaultFunctionArgumentInstantiation`
     * `DefaultTemplateArgumentChecking`
@@ -147,6 +150,11 @@ Format of `point_of_instantiation` is `<file_name>:<row>:<column>`. For example:
 `main.cpp:35:16`. There is a special file called `<stdin>` which can appear in
 this field. This is a placeholder for the the code directly entered into the
 shell.
+
+`time_taken` is given in seconds as a double. `time_taken_ratio` is also a
+double and can be generally expected to be in the range `[0-1]`. Sometimes it
+can get out of this range, if there is something wrong with how the compiler
+reports timings to Metashell.
 
 * __prompt__ <br />
 <br />

--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -381,8 +381,9 @@ Metaprogram started
 (mdb)
 ```
 
-From this point, you can use the usual commands to traverse the instantiation
-tree of the whole translation unit.
+The `-` means, that the final trace you can traverse is not constrained to a
+single expression, but to whole translation unit.  From this point, you can use
+the usual commands to traverse and inspect the instantiation tree.
 
 ### Full mode
 

--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -334,11 +334,62 @@ short) without giving any expression as an argument:
 Metaprogram started
 ```
 
+### Profiling
+
+Metadebugger can be used to profile template metaprograms. To enable profiling
+call `evaluate` or `#msh mdb` with the `-profile` flag:
+
+```cpp
+(mdb) evaluate -profile int_<fib<4>::value>
+Metaprogram started
+(mdb) ft
+int_<fib<4>::value>
++ [0.41ms, 76.89%] fib<4> (TemplateInstantiation)
+| + [0.14ms, 26.70%] fib<2> (TemplateInstantiation)
+| | + [0.01ms, 2.44%] fib<1> (Memoization)
+| | ` [0.01ms, 2.06%] fib<0> (Memoization)
+| ` [0.06ms, 11.84%] fib<3> (TemplateInstantiation)
+|   + [0.01ms, 1.12%] fib<1> (Memoization)
+|   ` [0.01ms, 0.94%] fib<2> (Memoization)
++ [0.05ms, 8.84%] int_<5> (TemplateInstantiation)
+` [0.01ms, 0.94%] fib<4> (Memoization)
+```
+
+Some extra information is printed every time a frame is printed by any command.
+You can see the absolute time taken by an instantiation and all of it's sub
+instantiations as well as an approximate ratio of the time taken by an
+instantiation and the full template instantiation process as a percentage.
+The sum of the percentages on the top level will never add up to 100% since the
+compiler does other things which are not shown in the trace.
+
+One more improtant difference in profile mode, is that the instantiations and
+sub instantiations are not ordered by the order which they were actually
+instantiated by the compiler, but the time they took the longest one being the
+first. This means that you can usually find the bottleneck just by looking at
+the first few steps of the metaprogram.
+
+#### Profiling a translation unit
+
+When trying to find out why a specific translation unit takes a long time to
+compile, you may want to see the trace for the full file, not just a single
+expression. You can do this with Metadebugger as well:
+
+```cpp
+> #include "file_which_takes_a_long_time_to_compile.cpp"
+> #msh mdb -profile -
+Metaprogram started
+(mdb)
+```
+
+From this point, you can use the usual commands to traverse the instantiation
+tree of the whole translation unit.
+
 ### Full mode
 
-There are two modes which Metadebugger can operate in. The normal mode, which
-was shown in the previous chapters, and the full mode. To demonstrate the
-difference let's evaluate a metaprogram in full mode and print the forwardtrace:
+There are three modes which Metadebugger can operate in. The normal mode and
+profiling mode which was shown in the previous chapters, and the full mode.
+To demonstrate the difference let's evaluate a metaprogram in full mode and
+print the forwardtrace:
 
 ```cpp
 (mdb) evaluate -full int_<fib<4>::value>

--- a/docs/reference/mdb_commands.md
+++ b/docs/reference/mdb_commands.md
@@ -3,10 +3,13 @@
 You can find the list of MDB commands here.
 
 <!-- mdb_info -->
-* __`evaluate [-full] [-profile] [<type>]`__ <br />
+* __`evaluate [-full|-profile] [<type>]`__ <br />
 Evaluate and start debugging a new metaprogram. <br />
 Evaluating a metaprogram using the `-full` qualifier will expand all
   Memoization events.
+  
+  Evaluating a metaprogram using the `-profile` qualifier will enable
+  profile mode.
   
   If called without `<type>`, then the last evaluated metaprogram will be
   reevaluated.
@@ -16,9 +19,6 @@ Evaluating a metaprogram using the `-full` qualifier will expand all
   Unlike metashell, evaluate doesn't use metashell::format to avoid cluttering
   the debugged metaprogram with unrelated code. If you need formatting, you can
   explicitly enter `metashell::format< <type> >::type` for the same effect.
-  
-  The qualifier `-profile` is intentionally undocumented. It is only used for
-  internal profiling, and could be changed or removed at any time.
 
 * __`step [over|out] [n]`__ <br />
 Step the program. <br />

--- a/docs/reference/mdb_commands.md
+++ b/docs/reference/mdb_commands.md
@@ -3,7 +3,7 @@
 You can find the list of MDB commands here.
 
 <!-- mdb_info -->
-* __`evaluate [-full|-profile] [<type>]`__ <br />
+* __`evaluate [-full|-profile] [<type>|-]`__ <br />
 Evaluate and start debugging a new metaprogram. <br />
 Evaluating a metaprogram using the `-full` qualifier will expand all
   Memoization events.
@@ -11,8 +11,11 @@ Evaluating a metaprogram using the `-full` qualifier will expand all
   Evaluating a metaprogram using the `-profile` qualifier will enable
   profile mode.
   
-  If called without `<type>`, then the last evaluated metaprogram will be
-  reevaluated.
+  Instead of `<type>`, evaluate can be called with `-`, in which case the
+  whole environment is being debugged not just a single type expression.
+  
+  If called without `<type>` or `-`, then the last evaluated metaprogram will
+  be reevaluated.
   
   Previous breakpoints are cleared.
   

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -50,6 +50,11 @@ namespace metashell
     bool _syntax_highlight;
 
     data::colored_string format_code(const std::string& c_);
+    data::colored_string format_frame(const data::frame& f_);
+
+    void display_node(
+      const data::call_graph_node& node_,
+      const std::vector<int>& depth_counter_);
   };
 }
 

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -20,6 +20,7 @@
 #include <metashell/iface/displayer.hpp>
 #include <metashell/iface/console.hpp>
 #include <metashell/data/file_location.hpp>
+#include <metashell/pager.hpp>
 
 namespace metashell
 {
@@ -55,7 +56,8 @@ namespace metashell
 
     void display_node(
       const data::call_graph_node& node_,
-      const std::vector<int>& depth_counter_);
+      const std::vector<int>& depth_counter_,
+      pager& pager_);
   };
 }
 

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -52,6 +52,7 @@ namespace metashell
 
     data::colored_string format_code(const std::string& c_);
     data::colored_string format_time(double time_in_seconds_);
+    data::colored_string format_ratio(double ratio_);
     data::colored_string format_frame(const data::frame& f_);
 
     bool display_frame_with_pager(const data::frame& frame_, pager& pager_);

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -54,7 +54,7 @@ namespace metashell
     data::colored_string format_time(double time_in_seconds_);
     data::colored_string format_frame(const data::frame& f_);
 
-    void display_node(
+    bool display_node(
       const data::call_graph_node& node_,
       const std::vector<int>& depth_counter_,
       pager& pager_);

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -50,6 +50,7 @@ namespace metashell
     bool _syntax_highlight;
 
     data::colored_string format_code(const std::string& c_);
+    data::colored_string format_time(double time_in_seconds_);
     data::colored_string format_frame(const data::frame& f_);
 
     void display_node(

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -49,7 +49,7 @@ namespace metashell
     bool _indent;
     bool _syntax_highlight;
 
-    void display_code(const std::string& c_);
+    data::colored_string format_code(const std::string& c_);
   };
 }
 

--- a/include/metashell/console_displayer.hpp
+++ b/include/metashell/console_displayer.hpp
@@ -54,6 +54,8 @@ namespace metashell
     data::colored_string format_time(double time_in_seconds_);
     data::colored_string format_frame(const data::frame& f_);
 
+    bool display_frame_with_pager(const data::frame& frame_, pager& pager_);
+
     bool display_node(
       const data::call_graph_node& node_,
       const std::vector<int>& depth_counter_,

--- a/include/metashell/data/frame.hpp
+++ b/include/metashell/data/frame.hpp
@@ -38,7 +38,8 @@ namespace metashell
       frame(const type& name_,
         const file_location& point_of_instantiation_,
         instantiation_kind kind_,
-        boost::optional<double> time_taken = boost::none);
+        boost::optional<double> time_taken = boost::none,
+        boost::optional<double> time_taken_ratio = boost::none);
 
       const type& name() const;
 
@@ -51,11 +52,13 @@ namespace metashell
 
       // precondition: is_profiled()
       double time_taken() const;
+      double time_taken_ratio() const;
     private:
       type _name;
       boost::optional<file_location> _point_of_instantiation;
       boost::optional<data::instantiation_kind> _kind;
       boost::optional<double> _time_taken;
+      boost::optional<double> _time_taken_ratio;
     };
 
     std::ostream& operator<<(std::ostream& o_, const frame& f_);

--- a/include/metashell/data/frame.hpp
+++ b/include/metashell/data/frame.hpp
@@ -33,8 +33,7 @@ namespace metashell
     public:
       frame() = default;
 
-      explicit frame(const type& name_,
-        boost::optional<double> time_taken = boost::none);
+      explicit frame(const type& name_);
 
       frame(const type& name_,
         const file_location& point_of_instantiation_,

--- a/include/metashell/data/frame.hpp
+++ b/include/metashell/data/frame.hpp
@@ -33,23 +33,30 @@ namespace metashell
     public:
       frame() = default;
 
-      explicit frame(const type& name_);
+      explicit frame(const type& name_,
+        boost::optional<double> time_taken = boost::none);
 
       frame(const type& name_,
         const file_location& point_of_instantiation_,
-        instantiation_kind kind_);
+        instantiation_kind kind_,
+        boost::optional<double> time_taken = boost::none);
 
       const type& name() const;
 
       bool is_full() const;
+      bool is_profiled() const;
 
       // precondition: is_full()
       instantiation_kind kind() const;
       const file_location& point_of_instantiation() const;
+
+      // precondition: is_profiled()
+      double time_taken() const;
     private:
       type _name;
       boost::optional<file_location> _point_of_instantiation;
       boost::optional<data::instantiation_kind> _kind;
+      boost::optional<double> _time_taken;
     };
 
     std::ostream& operator<<(std::ostream& o_, const frame& f_);

--- a/include/metashell/data/type_or_error.hpp
+++ b/include/metashell/data/type_or_error.hpp
@@ -31,12 +31,15 @@ public:
   typedef type type_type;
   typedef std::string error_type;
 
+  type_or_error();
   type_or_error(const type_type& t);
   type_or_error(const error_type& e);
 
+  static type_or_error make_none();
   static type_or_error make_type(const type_type& t);
   static type_or_error make_error(const error_type& e);
 
+  bool is_none() const;
   bool is_type() const;
   bool is_error() const;
 
@@ -46,7 +49,7 @@ public:
   bool operator==(const type_or_error& other) const;
 
 private:
-  typedef boost::variant<type_type, error_type> data_type;
+  typedef boost::variant<boost::blank, type_type, error_type> data_type;
   data_type data;
 };
 

--- a/include/metashell/forward_trace_iterator.hpp
+++ b/include/metashell/forward_trace_iterator.hpp
@@ -64,8 +64,7 @@ namespace metashell
 
     // The usual stack for DFS
     std::stack<stack_element> _to_visit;
-    const metaprogram::graph_t* _graph;
-    const metaprogram* _mp;
+    const metaprogram* _mp = nullptr;
     metaprogram::discovered_t _discovered;
 
     void visit(const metaprogram::optional_edge_descriptor& edge_, int depth_);

--- a/include/metashell/iface/console.hpp
+++ b/include/metashell/iface/console.hpp
@@ -32,6 +32,7 @@ namespace metashell
       virtual void new_line() = 0;
 
       virtual int width() const = 0;
+      virtual int height() const = 0;
     };
   }
 }

--- a/include/metashell/iface/console.hpp
+++ b/include/metashell/iface/console.hpp
@@ -26,10 +26,18 @@ namespace metashell
     class console
     {
     public:
-      virtual ~console() {}
+      enum class user_answer {
+        next_page,
+        show_all,
+        quit
+      };
+
+      virtual ~console() = default;
 
       virtual void show(const data::colored_string& s_) = 0;
       virtual void new_line() = 0;
+
+      virtual user_answer ask_for_continuation() = 0;
 
       virtual int width() const = 0;
       virtual int height() const = 0;

--- a/include/metashell/iface/displayer.hpp
+++ b/include/metashell/iface/displayer.hpp
@@ -53,7 +53,7 @@ namespace metashell
       void show_type_or_error(const data::type_or_error& te_) {
         if (te_.is_type()) {
           show_type(te_.get_type());
-        } else {
+        } else if (te_.is_error()) {
           show_error(te_.get_error());
         }
       }

--- a/include/metashell/iface/json_writer.hpp
+++ b/include/metashell/iface/json_writer.hpp
@@ -30,6 +30,7 @@ namespace metashell
 
       virtual void string(const std::string& value_) = 0;
       virtual void int_(int value_) = 0;
+      virtual void double_(double value_) = 0;
 
       virtual void start_object() = 0;
       virtual void key(const std::string& key_) = 0;

--- a/include/metashell/mdb_shell.hpp
+++ b/include/metashell/mdb_shell.hpp
@@ -93,7 +93,7 @@ protected:
 
   bool run_metaprogram_with_templight(
     const std::string& str,
-    bool full_mode,
+    metaprogram::mode_t mode,
     iface::displayer& displayer_
   );
   data::type_or_error run_metaprogram(

--- a/include/metashell/mdb_shell.hpp
+++ b/include/metashell/mdb_shell.hpp
@@ -105,10 +105,10 @@ protected:
   std::string trim_wrap_type(const std::string& type);
 
   void filter_disable_everything();
-  void filter_enable_reachable_from_current_line();
+  void filter_enable_reachable(bool for_current_line);
   void filter_unwrap_vertices();
   void filter_similar_edges();
-  void filter_metaprogram();
+  void filter_metaprogram(bool for_current_line);
 
   static boost::optional<int> parse_defaultable_integer(
     const std::string& arg, int default_value);
@@ -142,6 +142,10 @@ protected:
 
   std::string prev_line;
   bool last_command_repeatable = false;
+
+  // It is empty if evaluate was called with "-".
+  // mp is empty when there were no evaluations at all
+  boost::optional<std::string> last_evaluated_expression;
 
   bool is_stopped = false;
   logger* _logger;

--- a/include/metashell/mdb_shell.hpp
+++ b/include/metashell/mdb_shell.hpp
@@ -92,12 +92,12 @@ protected:
       iface::displayer& displayer_) const;
 
   bool run_metaprogram_with_templight(
-    const std::string& str,
+    const boost::optional<std::string>& expression,
     metaprogram::mode_t mode,
     iface::displayer& displayer_
   );
   data::type_or_error run_metaprogram(
-    const std::string& str,
+    const boost::optional<std::string>& expression,
     iface::displayer& displayer_
   );
 

--- a/include/metashell/metaprogram.hpp
+++ b/include/metashell/metaprogram.hpp
@@ -174,6 +174,9 @@ public:
   boost::iterator_range<out_edge_iterator> get_out_edges(
       vertex_descriptor vertex) const;
 
+  std::vector<edge_descriptor> get_filtered_out_edges(
+      vertex_descriptor vertex) const;
+
   boost::iterator_range<vertex_iterator> get_vertices() const;
   boost::iterator_range<edge_iterator> get_edges() const;
 

--- a/include/metashell/metaprogram.hpp
+++ b/include/metashell/metaprogram.hpp
@@ -69,6 +69,7 @@ public:
   struct edge_property {
     data::instantiation_kind kind;
     data::file_location point_of_instantiation;
+    double time_taken = 0.0;
     bool enabled = true;
   };
 
@@ -119,7 +120,8 @@ public:
       vertex_descriptor from,
       vertex_descriptor to,
       data::instantiation_kind kind,
-      const data::file_location& point_of_instantiation);
+      const data::file_location& point_of_instantiation,
+      double initial_time_stamp);
 
   bool is_empty() const;
 

--- a/include/metashell/metaprogram.hpp
+++ b/include/metashell/metaprogram.hpp
@@ -128,6 +128,8 @@ public:
       const data::file_location& point_of_instantiation,
       double initial_time_stamp);
 
+  void set_full_time_taken(double time_taken);
+
   bool is_empty() const;
 
   const data::type_or_error& get_evaluation_result() const;
@@ -209,6 +211,9 @@ private:
   vertex_descriptor root_vertex;
 
   data::type_or_error evaluation_result;
+
+  // Time taken to run the full metaprogram (used to show % in profiling data)
+  double full_time_taken = 0.0;
 };
 
 template<class P>

--- a/include/metashell/metaprogram.hpp
+++ b/include/metashell/metaprogram.hpp
@@ -39,7 +39,8 @@ class metaprogram {
 public:
   enum class mode_t {
     normal,
-    full
+    full,
+    profile
   };
 
   // Creates empty metaprogram: single <root> vertex

--- a/include/metashell/metaprogram.hpp
+++ b/include/metashell/metaprogram.hpp
@@ -158,7 +158,6 @@ public:
 
   unsigned get_traversal_count(vertex_descriptor vertex) const;
 
-  const graph_t& get_graph() const;
   const state_t& get_state() const;
 
   vertices_size_type get_num_vertices() const;

--- a/include/metashell/metaprogram.hpp
+++ b/include/metashell/metaprogram.hpp
@@ -37,22 +37,26 @@ enum class direction_t { forward, backwards };
 
 class metaprogram {
 public:
+  enum class mode_t {
+    normal,
+    full
+  };
 
   // Creates empty metaprogram: single <root> vertex
   metaprogram(
-      bool full_mode,
+      mode_t mode,
       const std::string& root_name,
       const data::type_or_error& evaluation_result);
 
   static metaprogram create_from_protobuf_stream(
       std::istream& stream,
-      bool full_mode,
+      mode_t mode,
       const std::string& root_name,
       const data::type_or_error& evaluation_result);
 
   static metaprogram create_from_protobuf_string(
       const std::string& string,
-      bool full_mode,
+      mode_t mode,
       const std::string& root_name,
       const data::type_or_error& evaluation_result);
 
@@ -129,7 +133,7 @@ public:
 
   void reset_state();
 
-  bool is_in_full_mode() const;
+  mode_t get_mode() const;
 
   bool is_at_endpoint(direction_t direction) const;
   bool is_finished() const;
@@ -196,7 +200,7 @@ private:
   state_t state;
   state_history_t state_history;
 
-  bool full_mode;
+  mode_t mode;
 
   // This should be generally 0
   vertex_descriptor root_vertex;
@@ -212,6 +216,8 @@ void metaprogram::disable_edges_if(P pred) {
     }
   }
 }
+
+std::ostream& operator<<(std::ostream& os, metaprogram::mode_t mode);
 
 }
 

--- a/include/metashell/metaprogram_builder.hpp
+++ b/include/metashell/metaprogram_builder.hpp
@@ -24,7 +24,8 @@
 
 namespace metashell {
 
-struct metaprogram_builder {
+class metaprogram_builder {
+public:
 
   metaprogram_builder(
       bool full_mode,
@@ -34,21 +35,23 @@ struct metaprogram_builder {
   void handle_template_begin(
     data::instantiation_kind kind,
     const std::string& context,
-    const data::file_location& location);
+    const data::file_location& location,
+    double time_stamp);
 
-  void handle_template_end();
+  void handle_template_end(double time_stamp);
 
   const metaprogram& get_metaprogram() const;
 
 private:
   typedef metaprogram::vertex_descriptor vertex_descriptor;
+  typedef metaprogram::edge_descriptor edge_descriptor;
   typedef std::map<std::string, vertex_descriptor> element_vertex_map_t;
 
   vertex_descriptor add_vertex(const std::string& context);
 
   metaprogram mp;
 
-  std::stack<vertex_descriptor> vertex_stack;
+  std::stack<edge_descriptor> edge_stack;
 
   element_vertex_map_t element_vertex_map;
 };

--- a/include/metashell/metaprogram_builder.hpp
+++ b/include/metashell/metaprogram_builder.hpp
@@ -40,7 +40,7 @@ public:
 
   void handle_template_end(double time_stamp);
 
-  const metaprogram& get_metaprogram() const;
+  const metaprogram& get_metaprogram();
 
 private:
   typedef metaprogram::vertex_descriptor vertex_descriptor;
@@ -50,6 +50,8 @@ private:
   vertex_descriptor add_vertex(const std::string& context);
 
   metaprogram mp;
+  double first_time_stamp = 0.0;
+  double last_time_stamp = 0.0;
 
   std::stack<edge_descriptor> edge_stack;
 

--- a/include/metashell/metaprogram_builder.hpp
+++ b/include/metashell/metaprogram_builder.hpp
@@ -28,7 +28,7 @@ class metaprogram_builder {
 public:
 
   metaprogram_builder(
-      bool full_mode,
+      metaprogram::mode_t mode,
       const std::string& root_name,
       const data::type_or_error& evaluation_result);
 

--- a/include/metashell/metashell.hpp
+++ b/include/metashell/metashell.hpp
@@ -33,6 +33,13 @@ namespace metashell
   std::string repair_type_string(const std::string& type);
   std::string get_type_from_ast_string(const std::string& ast);
 
+  result run_clang(
+    const std::string& clang_path_,
+    std::vector<std::string> clang_args_,
+    const std::string& input_,
+    logger* logger_
+  );
+
   result eval_tmp_formatted(
     const iface::environment& env_,
     const std::string& tmp_exp_,

--- a/include/metashell/metashell.hpp
+++ b/include/metashell/metashell.hpp
@@ -46,6 +46,11 @@ namespace metashell
     const config& config_,
     logger* logger_);
 
+  result eval_environment(
+    const iface::environment& env_,
+    const config& config_,
+    logger* logger_);
+
   result validate_code(
     const std::string& s_,
     const config& config_,

--- a/include/metashell/metashell.hpp
+++ b/include/metashell/metashell.hpp
@@ -33,13 +33,6 @@ namespace metashell
   std::string repair_type_string(const std::string& type);
   std::string get_type_from_ast_string(const std::string& ast);
 
-  result run_clang(
-    const std::string& clang_path_,
-    std::vector<std::string> clang_args_,
-    const std::string& input_,
-    logger* logger_
-  );
-
   result eval_tmp_formatted(
     const iface::environment& env_,
     const std::string& tmp_exp_,

--- a/include/metashell/null_json_writer.hpp
+++ b/include/metashell/null_json_writer.hpp
@@ -26,6 +26,7 @@ namespace metashell
   public:
     virtual void string(const std::string& value_) override;
     virtual void int_(int value_) override;
+    virtual void double_(double value) override;
 
     virtual void start_object() override;
     virtual void key(const std::string& key_) override;

--- a/include/metashell/pager.hpp
+++ b/include/metashell/pager.hpp
@@ -31,6 +31,8 @@ public:
 private:
   iface::console& console_;
 
+  int lines_in_current_page = 0;
+  int chars_in_current_line = 0;
 };
 
 } // namespace metashell

--- a/include/metashell/pager.hpp
+++ b/include/metashell/pager.hpp
@@ -26,10 +26,12 @@ public:
   pager(iface::console& console);
 
   void show(const data::colored_string& string);
-  void new_line();
+  bool new_line();
 
 private:
   iface::console& console_;
+
+  bool show_all = false;
 
   int lines_in_current_page = 0;
   int chars_in_current_line = 0;

--- a/include/metashell/pager.hpp
+++ b/include/metashell/pager.hpp
@@ -1,0 +1,38 @@
+#ifndef METASHELL_PAGER_HPP
+#define METASHELL_PAGER_HPP
+
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell/iface/console.hpp>
+
+namespace metashell {
+
+class pager {
+public:
+  pager(iface::console& console);
+
+  void show(const data::colored_string& string);
+  void new_line();
+
+private:
+  iface::console& console_;
+
+};
+
+} // namespace metashell
+
+#endif

--- a/include/metashell/rapid_json_writer.hpp
+++ b/include/metashell/rapid_json_writer.hpp
@@ -33,6 +33,7 @@ namespace metashell
 
     virtual void string(const std::string& value_) override;
     virtual void int_(int value_) override;
+    virtual void double_(double value_) override;
 
     virtual void start_object() override;
     virtual void key(const std::string& key_) override;

--- a/include/metashell/stdout_console.hpp
+++ b/include/metashell/stdout_console.hpp
@@ -28,6 +28,7 @@ namespace metashell
     virtual void new_line() override;
 
     virtual int width() const override;
+    virtual int height() const override;
   };
 }
 

--- a/include/metashell/stdout_console.hpp
+++ b/include/metashell/stdout_console.hpp
@@ -27,6 +27,8 @@ namespace metashell
     virtual void show(const data::colored_string& s_) override;
     virtual void new_line() override;
 
+    virtual user_answer ask_for_continuation() override;
+
     virtual int width() const override;
     virtual int height() const override;
   };

--- a/include/metashell/stream_console.hpp
+++ b/include/metashell/stream_console.hpp
@@ -32,6 +32,7 @@ namespace metashell
     virtual void new_line() override;
 
     virtual int width() const override;
+    virtual int height() const override;
   private:
     std::ostream* _s;
   };

--- a/include/metashell/stream_console.hpp
+++ b/include/metashell/stream_console.hpp
@@ -31,6 +31,8 @@ namespace metashell
     virtual void show(const data::colored_string& s_) override;
     virtual void new_line() override;
 
+    virtual user_answer ask_for_continuation() override;
+
     virtual int width() const override;
     virtual int height() const override;
   private:

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -255,7 +255,7 @@ data::colored_string console_displayer::format_frame(const data::frame& f_)
   return prefix + format_code(f_.name().name()) + postfix.str();
 }
 
-void console_displayer::display_node(
+bool console_displayer::display_node(
   const data::call_graph_node& node_,
   const std::vector<int>& depth_counter_,
   pager& pager_)
@@ -277,7 +277,6 @@ void console_displayer::display_node(
     display_trace_graph(node_.depth(), depth_counter_, true, pager_);
 
     pager_.show(element_content);
-    pager_.new_line();
   }
   else
   {
@@ -286,9 +285,9 @@ void console_displayer::display_node(
     {
       display_trace_graph(node_.depth(), depth_counter_, i == 0, pager_);
       pager_.show(element_content.substr(i, content_width));
-      pager_.new_line();
     }
   }
+  return pager_.new_line();
 }
 
 void console_displayer::show_frame(const data::frame& frame_)
@@ -356,7 +355,10 @@ void console_displayer::show_call_graph(const iface::call_graph& cg_)
   {
     --depth_counter[n.depth()];
 
-    display_node(n, depth_counter, pager);
+    if (!display_node(n, depth_counter, pager))
+    {
+      return;
+    }
 
     if (depth_counter.size() <= static_cast<unsigned int>(n.depth()+1))
     {

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -231,12 +231,20 @@ data::colored_string console_displayer::format_code(const std::string& code_)
   }
 }
 
+data::colored_string console_displayer::format_time(double time_in_seconds_)
+{
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2);
+  ss << time_in_seconds_ * 1000.0 << "ms";
+  return ss.str();
+}
+
 data::colored_string console_displayer::format_frame(const data::frame& f_)
 {
-  std::ostringstream prefix;
+  data::colored_string prefix;
   if (f_.is_profiled())
   {
-    prefix << "[" << f_.time_taken() << "] ";
+    prefix = "[" + format_time(f_.time_taken()) + "] ";
   }
   std::ostringstream postfix;
   if (f_.is_full())
@@ -244,7 +252,7 @@ data::colored_string console_displayer::format_frame(const data::frame& f_)
     postfix
       << " (" << f_.kind() <<" from " << f_.point_of_instantiation() << ")";
   }
-  return prefix.str() + format_code(f_.name().name()) + postfix.str();
+  return prefix + format_code(f_.name().name()) + postfix.str();
 }
 
 void console_displayer::display_node(

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -54,7 +54,64 @@ namespace
       f_
     );
   }
-}
+
+  data::color get_color(int n_)
+  {
+    data::color cs[] = {
+      data::color::red,
+      data::color::green,
+      data::color::yellow,
+      data::color::blue,
+      data::color::cyan
+    };
+    return cs[n_ % (sizeof(cs) / sizeof(cs[0]))];
+  }
+
+  void display_trace_graph(
+    int depth_,
+    const std::vector<int>& depth_counter_,
+    bool print_mark_,
+    iface::console& console_
+  )
+  {
+    assert(depth_counter_.size() > static_cast<unsigned int>(depth_));
+
+    if (depth_ > 0)
+    {
+      //TODO respect the -H (no syntax highlight parameter)
+      for (int i = 1; i < depth_; ++i)
+      {
+        console_.show(
+          data::colored_string(
+            depth_counter_[i] > 0 ? "| " : "  ",
+            get_color(i)
+          )
+        );
+      }
+
+      const data::color mark_color = get_color(depth_);
+      if (print_mark_)
+      {
+        if (depth_counter_[depth_] == 0)
+        {
+          console_.show(data::colored_string("` ", mark_color));
+        }
+        else
+        {
+          console_.show(data::colored_string("+ ", mark_color));
+        }
+      }
+      else if (depth_counter_[depth_] > 0)
+      {
+        console_.show(data::colored_string("| ", mark_color));
+      }
+      else
+      {
+        console_.show("  ");
+      }
+    }
+  }
+} // anonymouse namespace
 
 console_displayer::console_displayer(
   iface::console& console_,
@@ -174,16 +231,60 @@ data::colored_string console_displayer::format_code(const std::string& code_)
   }
 }
 
+data::colored_string console_displayer::format_frame(const data::frame& f_)
+{
+  std::ostringstream prefix;
+  if (f_.is_profiled())
+  {
+    prefix << "[" << f_.time_taken() << "] ";
+  }
+  std::ostringstream postfix;
+  if (f_.is_full())
+  {
+    postfix
+      << " (" << f_.kind() <<" from " << f_.point_of_instantiation() << ")";
+  }
+  return prefix.str() + format_code(f_.name().name()) + postfix.str();
+}
+
+void console_displayer::display_node(
+  const data::call_graph_node& node_,
+  const std::vector<int>& depth_counter_)
+{
+  const auto width = _console->width();
+
+  const data::colored_string
+    element_content = format_frame(node_.current_frame());
+
+  const int non_content_length = 2*node_.depth();
+
+  const int pretty_print_threshold = 10;
+  if (
+    width < pretty_print_threshold
+    || non_content_length >= width - pretty_print_threshold
+  )
+  {
+    // We have no chance to display the graph nicely :(
+    display_trace_graph(node_.depth(), depth_counter_, true, *_console);
+
+    _console->show(element_content);
+    _console->new_line();
+  }
+  else
+  {
+    int content_width = width - non_content_length;
+    for (unsigned i = 0; i < element_content.size(); i += content_width)
+    {
+      display_trace_graph(node_.depth(), depth_counter_, i == 0, *_console);
+      _console->show(element_content.substr(i, content_width));
+      _console->new_line();
+    }
+  }
+}
+
 void console_displayer::show_frame(const data::frame& frame_)
 {
-  _console->show(format_code(frame_.name().name()));
-  if (frame_.is_full())
-  {
-    std::ostringstream s;
-    s << " (" << frame_.kind()
-      << " from " << frame_.point_of_instantiation() << ")";
-    _console->show(s.str());
-  }
+  _console->show(format_frame(frame_));
   _console->new_line();
 }
 
@@ -233,122 +334,9 @@ void console_displayer::show_backtrace(const data::backtrace& trace_)
   }
 }
 
-namespace
-{
-  data::color get_color(int n_)
-  {
-    data::color cs[] = {
-      data::color::red,
-      data::color::green,
-      data::color::yellow,
-      data::color::blue,
-      data::color::cyan
-    };
-    return cs[n_ % (sizeof(cs) / sizeof(cs[0]))];
-  }
-
-  void display_trace_graph(
-    int depth_,
-    const std::vector<int>& depth_counter_,
-    bool print_mark_,
-    iface::console& console_
-  )
-  {
-    assert(depth_counter_.size() > static_cast<unsigned int>(depth_));
-
-    if (depth_ > 0)
-    {
-      //TODO respect the -H (no syntax highlight parameter)
-      for (int i = 1; i < depth_; ++i)
-      {
-        console_.show(
-          data::colored_string(
-            depth_counter_[i] > 0 ? "| " : "  ",
-            get_color(i)
-          )
-        );
-      }
-
-      const data::color mark_color = get_color(depth_);
-      if (print_mark_)
-      {
-        if (depth_counter_[depth_] == 0)
-        {
-          console_.show(data::colored_string("` ", mark_color));
-        }
-        else
-        {
-          console_.show(data::colored_string("+ ", mark_color));
-        }
-      }
-      else if (depth_counter_[depth_] > 0)
-      {
-        console_.show(data::colored_string("| ", mark_color));
-      }
-      else
-      {
-        console_.show("  ");
-      }
-    }
-  }
-
-  data::colored_string format_frame(const data::frame& f_)
-  {
-    std::ostringstream prefix;
-    if (f_.is_profiled())
-    {
-      prefix << "[" << f_.time_taken() << "] ";
-    }
-    std::ostringstream postfix;
-    if (f_.is_full())
-    {
-      postfix
-        << " (" << f_.kind() <<" from " << f_.point_of_instantiation() << ")";
-    }
-    return prefix.str() + highlight_syntax(f_.name().name()) + postfix.str();
-  }
-
-  void display_node(
-    const data::call_graph_node& node_,
-    const std::vector<int>& depth_counter_,
-    int width_,
-    iface::console& console_
-  )
-  {
-    const data::colored_string
-      element_content = format_frame(node_.current_frame());
-
-    const int non_content_length = 2*node_.depth();
-
-    const int pretty_print_threshold = 10;
-    if (
-      width_ < pretty_print_threshold
-      || non_content_length >= width_ - pretty_print_threshold
-    )
-    {
-      // We have no chance to display the graph nicely :(
-      display_trace_graph(node_.depth(), depth_counter_, true, console_);
-
-      console_.show(element_content);
-      console_.new_line();
-    }
-    else
-    {
-      int content_width = width_ - non_content_length;
-      for (unsigned i = 0; i < element_content.size(); i += content_width)
-      {
-        display_trace_graph(node_.depth(), depth_counter_, i == 0, console_);
-        console_.show(element_content.substr(i, content_width));
-        console_.new_line();
-      }
-    }
-  }
-}
 
 void console_displayer::show_call_graph(const iface::call_graph& cg_)
 {
-  const auto width = _console->width();
-
   std::vector<int> depth_counter(1);
 
   ++depth_counter[0]; // This value is neved read
@@ -357,7 +345,7 @@ void console_displayer::show_call_graph(const iface::call_graph& cg_)
   {
     --depth_counter[n.depth()];
 
-    display_node(n, depth_counter, width, *_console);
+    display_node(n, depth_counter);
 
     if (depth_counter.size() <= static_cast<unsigned int>(n.depth()+1))
     {

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -71,7 +71,7 @@ namespace
     int depth_,
     const std::vector<int>& depth_counter_,
     bool print_mark_,
-    iface::console& console_
+    pager& pager_
   )
   {
     assert(depth_counter_.size() > static_cast<unsigned int>(depth_));
@@ -81,7 +81,7 @@ namespace
       //TODO respect the -H (no syntax highlight parameter)
       for (int i = 1; i < depth_; ++i)
       {
-        console_.show(
+        pager_.show(
           data::colored_string(
             depth_counter_[i] > 0 ? "| " : "  ",
             get_color(i)
@@ -94,20 +94,20 @@ namespace
       {
         if (depth_counter_[depth_] == 0)
         {
-          console_.show(data::colored_string("` ", mark_color));
+          pager_.show(data::colored_string("` ", mark_color));
         }
         else
         {
-          console_.show(data::colored_string("+ ", mark_color));
+          pager_.show(data::colored_string("+ ", mark_color));
         }
       }
       else if (depth_counter_[depth_] > 0)
       {
-        console_.show(data::colored_string("| ", mark_color));
+        pager_.show(data::colored_string("| ", mark_color));
       }
       else
       {
-        console_.show("  ");
+        pager_.show("  ");
       }
     }
   }
@@ -257,7 +257,8 @@ data::colored_string console_displayer::format_frame(const data::frame& f_)
 
 void console_displayer::display_node(
   const data::call_graph_node& node_,
-  const std::vector<int>& depth_counter_)
+  const std::vector<int>& depth_counter_,
+  pager& pager_)
 {
   const auto width = _console->width();
 
@@ -273,19 +274,19 @@ void console_displayer::display_node(
   )
   {
     // We have no chance to display the graph nicely :(
-    display_trace_graph(node_.depth(), depth_counter_, true, *_console);
+    display_trace_graph(node_.depth(), depth_counter_, true, pager_);
 
-    _console->show(element_content);
-    _console->new_line();
+    pager_.show(element_content);
+    pager_.new_line();
   }
   else
   {
     int content_width = width - non_content_length;
     for (unsigned i = 0; i < element_content.size(); i += content_width)
     {
-      display_trace_graph(node_.depth(), depth_counter_, i == 0, *_console);
-      _console->show(element_content.substr(i, content_width));
-      _console->new_line();
+      display_trace_graph(node_.depth(), depth_counter_, i == 0, pager_);
+      pager_.show(element_content.substr(i, content_width));
+      pager_.new_line();
     }
   }
 }
@@ -345,6 +346,8 @@ void console_displayer::show_backtrace(const data::backtrace& trace_)
 
 void console_displayer::show_call_graph(const iface::call_graph& cg_)
 {
+  pager pager(*_console);
+
   std::vector<int> depth_counter(1);
 
   ++depth_counter[0]; // This value is neved read
@@ -353,7 +356,7 @@ void console_displayer::show_call_graph(const iface::call_graph& cg_)
   {
     --depth_counter[n.depth()];
 
-    display_node(n, depth_counter);
+    display_node(n, depth_counter, pager);
 
     if (depth_counter.size() <= static_cast<unsigned int>(n.depth()+1))
     {

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -277,6 +277,7 @@ bool console_displayer::display_node(
     display_trace_graph(node_.depth(), depth_counter_, true, pager_);
 
     pager_.show(element_content);
+    return pager_.new_line();
   }
   else
   {
@@ -285,9 +286,12 @@ bool console_displayer::display_node(
     {
       display_trace_graph(node_.depth(), depth_counter_, i == 0, pager_);
       pager_.show(element_content.substr(i, content_width));
+      if (!pager_.new_line()) {
+        return false;
+      }
     }
+    return true;
   }
-  return pager_.new_line();
 }
 
 void console_displayer::show_frame(const data::frame& frame_)

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -255,6 +255,13 @@ data::colored_string console_displayer::format_frame(const data::frame& f_)
   return prefix + format_code(f_.name().name()) + postfix.str();
 }
 
+bool console_displayer::display_frame_with_pager(
+  const data::frame& frame_, pager& pager_)
+{
+  pager_.show(format_frame(frame_));
+  return pager_.new_line();
+}
+
 bool console_displayer::display_node(
   const data::call_graph_node& node_,
   const std::vector<int>& depth_counter_,
@@ -335,13 +342,17 @@ void console_displayer::show_file_section(
 
 void console_displayer::show_backtrace(const data::backtrace& trace_)
 {
+  pager pager(*_console);
+
   int i = 0;
   for (const data::frame& f : trace_)
   {
     std::ostringstream s;
     s << "#" << i << " ";
-    _console->show(data::colored_string(s.str(), data::color::white));
-    show_frame(f);
+    pager.show(data::colored_string(s.str(), data::color::white));
+    if (!display_frame_with_pager(f, pager)) {
+      break;
+    }
     ++i;
   }
 }

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -239,12 +239,22 @@ data::colored_string console_displayer::format_time(double time_in_seconds_)
   return ss.str();
 }
 
+data::colored_string console_displayer::format_ratio(double ratio_)
+{
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2);
+  ss << ratio_ * 100.0 << "%";
+  return ss.str();
+}
+
 data::colored_string console_displayer::format_frame(const data::frame& f_)
 {
   data::colored_string prefix;
   if (f_.is_profiled())
   {
-    prefix = "[" + format_time(f_.time_taken()) + "] ";
+    prefix =
+      "[" + format_time(f_.time_taken()) +
+      ", " + format_ratio(f_.time_taken_ratio()) + "] ";
   }
   std::ostringstream postfix;
   if (f_.is_full())

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -156,27 +156,27 @@ void console_displayer::show_cpp_code(const std::string& code_)
     }
     else
     {
-      display_code(code_);
+      _console->show(format_code(code_));
     }
     _console->new_line();
   }
 }
 
-void console_displayer::display_code(const std::string& code_)
+data::colored_string console_displayer::format_code(const std::string& code_)
 {
   if (_syntax_highlight)
   {
-    _console->show(highlight_syntax(code_));
+    return highlight_syntax(code_);
   }
   else
   {
-    _console->show(code_);
+    return code_;
   }
 }
 
 void console_displayer::show_frame(const data::frame& frame_)
 {
-  display_code(frame_.name().name());
+  _console->show(format_code(frame_.name().name()));
   if (frame_.is_full())
   {
     std::ostringstream s;
@@ -215,7 +215,7 @@ void console_displayer::show_file_section(
     ss << indexed_line.line_index << "  ";
 
     _console->show(ss.str());
-    display_code(indexed_line.line);
+    _console->show(format_code(indexed_line.line));
     _console->new_line();
   }
 }

--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -294,12 +294,18 @@ namespace
 
   data::colored_string format_frame(const data::frame& f_)
   {
-    std::ostringstream s;
+    std::ostringstream prefix;
+    if (f_.is_profiled())
+    {
+      prefix << "[" << f_.time_taken() << "] ";
+    }
+    std::ostringstream postfix;
     if (f_.is_full())
     {
-      s << " (" << f_.kind() << " from " << f_.point_of_instantiation() << ")";
+      postfix
+        << " (" << f_.kind() <<" from " << f_.point_of_instantiation() << ")";
     }
-    return highlight_syntax(f_.name().name()) + s.str();
+    return prefix.str() + highlight_syntax(f_.name().name()) + postfix.str();
   }
 
   void display_node(

--- a/lib/core/forward_trace_iterator.cpp
+++ b/lib/core/forward_trace_iterator.cpp
@@ -77,7 +77,7 @@ void forward_trace_iterator::visit(
 
   if (!_discovered[vertex])
   {
-    if (!_mp->is_in_full_mode())
+    if (_mp->get_mode() != metaprogram::mode_t::full)
     {
       _discovered[vertex] = true;
     }

--- a/lib/core/forward_trace_iterator.cpp
+++ b/lib/core/forward_trace_iterator.cpp
@@ -16,31 +16,9 @@
 
 #include <metashell/forward_trace_iterator.hpp>
 
-#include <boost/range/adaptor/reversed.hpp>
-
 #include <algorithm>
 
 using namespace metashell;
-
-namespace
-{
-  int number_of_children(
-    const metashell::metaprogram& mp_,
-    const metashell::metaprogram::graph_t& graph_,
-    const metashell::metaprogram::vertex_descriptor& vertex_
-  )
-  {
-    typedef metashell::metaprogram::edge_descriptor edsc;
-
-    const auto oe = boost::out_edges(vertex_, graph_);
-    return
-      std::count_if(
-        oe.first,
-        oe.second,
-        [&mp_](const edsc& ed) { return mp_.get_edge_property(ed).enabled; }
-      );
-  }
-}
 
 forward_trace_iterator::forward_trace_iterator() :
   _finished(true)
@@ -52,7 +30,6 @@ forward_trace_iterator::forward_trace_iterator(
 ) :
   _finished(false),
   _max_depth(max_depth_),
-  _graph(&mp_.get_graph()),
   _mp(&mp_),
   _discovered(mp_.get_state().discovered)
 {
@@ -72,7 +49,7 @@ void forward_trace_iterator::visit(
       edge_ ? _mp->to_frame(*edge_) : _mp->get_root_frame(),
       depth_,
       (_discovered[vertex] || (_max_depth && *_max_depth <= depth_)) ?
-        0 : number_of_children(*_mp, *_graph, vertex)
+        0 : _mp->get_enabled_out_degree(vertex)
     );
 
   if (!_discovered[vertex])

--- a/lib/core/forward_trace_iterator.cpp
+++ b/lib/core/forward_trace_iterator.cpp
@@ -84,22 +84,10 @@ void forward_trace_iterator::visit(
 
     if (!_max_depth || *_max_depth > depth_)
     {
-      metaprogram::out_edge_iterator begin, end;
-      std::tie(begin, end) = boost::out_edges(vertex, *_graph);
-
-      std::vector<metaprogram::edge_descriptor> edges(begin, end);
-
-      // Reverse iteration, so types that got instantiated first
-      // get on the top of the stack
-      for (
-        const metaprogram::edge_descriptor& out_edge :
-          edges | boost::adaptors::reversed
-      )
+      auto edges = _mp->get_filtered_out_edges(vertex);
+      for (const metaprogram::edge_descriptor& out_edge : edges)
       {
-        if (_mp->get_edge_property(out_edge).enabled)
-        {
-          _to_visit.push(std::make_tuple(out_edge, depth_ + 1));
-        }
+        _to_visit.push(std::make_tuple(out_edge, depth_ + 1));
       }
     }
   }

--- a/lib/core/json_displayer.cpp
+++ b/lib/core/json_displayer.cpp
@@ -50,6 +50,13 @@ namespace
       writer_.key("point_of_instantiation");
       writer_.string(to_string(frame_.point_of_instantiation()));
     }
+    if (frame_.is_profiled())
+    {
+      writer_.key("time_taken");
+      writer_.double_(frame_.time_taken());
+      writer_.key("time_taken_ratio");
+      writer_.double_(frame_.time_taken_ratio());
+    }
   }
 }
 

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -538,8 +538,8 @@ void mdb_shell::filter_similar_edges() {
   using edge_descriptor = metaprogram::edge_descriptor;
   using edge_property = metaprogram::edge_property;
 
-  auto comparator =
-    mp->is_in_full_mode() ? less_than_ignore_instantiation_kind : less_than;
+  auto comparator = mp->get_mode() == metaprogram::mode_t::full ?
+    less_than_ignore_instantiation_kind : less_than;
 
   // Clang sometimes produces equivalent instantiations events from the same
   // point. Filter out all but one of each
@@ -616,7 +616,10 @@ void mdb_shell::command_evaluate(
 
   breakpoints.clear();
 
-  if (!run_metaprogram_with_templight(arg, has_full, displayer_)) {
+  metaprogram::mode_t mode =
+    has_full ? metaprogram::mode_t::full : metaprogram::mode_t::normal;
+
+  if (!run_metaprogram_with_templight(arg, mode, displayer_)) {
     return;
   }
 
@@ -789,7 +792,9 @@ void mdb_shell::command_quit(
 }
 
 bool mdb_shell::run_metaprogram_with_templight(
-    const std::string& str, bool full_mode, iface::displayer& displayer_)
+    const std::string& str,
+    metaprogram::mode_t mode,
+    iface::displayer& displayer_)
 {
   temporary_file templight_output_file("templight.pb");
   std::string output_path = templight_output_file.get_path();
@@ -815,7 +820,7 @@ bool mdb_shell::run_metaprogram_with_templight(
   }
 
   mp = metaprogram::create_from_protobuf_stream(
-      protobuf_stream, full_mode, str, evaluation_result);
+      protobuf_stream, mode, str, evaluation_result);
 
   assert(mp);
   if (mp->is_empty() && evaluation_result.is_error()) {

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -95,14 +95,16 @@ const mdb_command_handler_map mdb_shell::command_handler =
     {
       {{"evaluate"}, repeatable_t::non_repeatable,
         callback(&mdb_shell::command_evaluate),
-        "[-full|-profile] [<type>]",
+        "[-full|-profile] [<type>|-]",
         "Evaluate and start debugging a new metaprogram.",
         "Evaluating a metaprogram using the `-full` qualifier will expand all\n"
         "Memoization events.\n\n"
         "Evaluating a metaprogram using the `-profile` qualifier will enable\n"
         "profile mode.\n\n"
-        "If called without `<type>`, then the last evaluated metaprogram will be\n"
-        "reevaluated.\n\n"
+        "Instead of `<type>`, evaluate can be called with `-`, in which case the\n"
+        "whole environment is being debugged not just a single type expression.\n\n"
+        "If called without `<type>` or `-`, then the last evaluated metaprogram will\n"
+        "be reevaluated.\n\n"
         "Previous breakpoints are cleared.\n\n"
         "Unlike metashell, evaluate doesn't use metashell::format to avoid cluttering\n"
         "the debugged metaprogram with unrelated code. If you need formatting, you can\n"

--- a/lib/core/mdb_shell.cpp
+++ b/lib/core/mdb_shell.cpp
@@ -24,7 +24,6 @@
 #include <metashell/null_history.hpp>
 
 #include <cmath>
-#include <chrono>
 #include <sstream>
 #include <fstream>
 
@@ -617,38 +616,13 @@ void mdb_shell::command_evaluate(
 
   breakpoints.clear();
 
-  using clock_type = std::chrono::steady_clock;
-
-  auto run_start_time = clock_type::now();
   if (!run_metaprogram_with_templight(arg, has_full, displayer_)) {
     return;
   }
-  auto run_end_time = clock_type::now();
 
   displayer_.show_raw_text("Metaprogram started");
 
-  auto filter_start_time = clock_type::now();
   filter_metaprogram();
-  auto filter_end_time = clock_type::now();
-
-  if (has_profile) {
-    using std::chrono::duration_cast;
-    using std::chrono::milliseconds;
-
-    std::stringstream ss;
-
-    ss << "Profiling information:\n" <<
-      "Running time = " <<
-      duration_cast<milliseconds>(run_end_time - run_start_time).count() <<
-      "ms\n" <<
-      "Filtering time = " <<
-      duration_cast<milliseconds>(filter_end_time - filter_start_time).count() <<
-      "ms\n" <<
-      "Graph node count = " << mp->get_num_vertices() << "\n" <<
-      "Graph edge count = " << mp->get_num_edges();
-
-    displayer_.show_raw_text(ss.str());
-  }
 }
 
 void mdb_shell::command_forwardtrace(

--- a/lib/core/metaprogram.cpp
+++ b/lib/core/metaprogram.cpp
@@ -324,12 +324,19 @@ metaprogram::optional_edge_descriptor metaprogram::get_current_edge() const {
 data::frame metaprogram::to_frame(const edge_descriptor& e_) const
 {
   const data::type t(get_vertex_property(get_target(e_)).name);
-  return
-    get_mode() == mode_t::full ?
-      data::frame(t) :
-      data::frame(t,
-          get_edge_property(e_).point_of_instantiation,
-          get_edge_property(e_).kind);
+  const auto& ep = get_edge_property(e_);
+
+  switch (get_mode()) {
+    case mode_t::normal:
+      return data::frame(t, ep.point_of_instantiation, ep.kind);
+    case mode_t::full:
+      return data::frame(t);
+    case mode_t::profile:
+      return data::frame(t, ep.point_of_instantiation, ep.kind, ep.time_taken);
+  };
+  // unreachable
+  assert(false);
+  return data::frame(t);
 }
 
 data::frame metaprogram::get_current_frame() const {
@@ -425,6 +432,7 @@ std::ostream& operator<<(std::ostream& os, metaprogram::mode_t mode) {
   switch (mode) {
     case metaprogram::mode_t::normal: os << "normal"; break;
     case metaprogram::mode_t::full: os << "full"; break;
+    case metaprogram::mode_t::profile: os << "profile"; break;
   }
   return os;
 }

--- a/lib/core/metaprogram.cpp
+++ b/lib/core/metaprogram.cpp
@@ -377,6 +377,7 @@ data::frame metaprogram::to_frame(const edge_descriptor& e_) const
 }
 
 data::frame metaprogram::get_current_frame() const {
+  assert(!is_at_start());
   assert(!is_finished());
 
   return to_frame(*state.edge_stack.top());

--- a/lib/core/metaprogram.cpp
+++ b/lib/core/metaprogram.cpp
@@ -116,7 +116,7 @@ bool metaprogram::is_at_endpoint(direction_t direction) const {
 }
 
 bool metaprogram::is_finished() const {
-  if (evaluation_result.is_type()) {
+  if (evaluation_result.is_type() || evaluation_result.is_none()) {
     return state.edge_stack.empty();
   }
 

--- a/lib/core/metaprogram.cpp
+++ b/lib/core/metaprogram.cpp
@@ -207,10 +207,6 @@ void metaprogram::step_back() {
   state_history.pop();
 }
 
-const metaprogram::graph_t& metaprogram::get_graph() const {
-  return graph;
-}
-
 const metaprogram::state_t& metaprogram::get_state() const {
   return state;
 }

--- a/lib/core/metaprogram.cpp
+++ b/lib/core/metaprogram.cpp
@@ -56,7 +56,8 @@ metaprogram::edge_descriptor metaprogram::add_edge(
     vertex_descriptor from,
     vertex_descriptor to,
     data::instantiation_kind kind,
-    const data::file_location& point_of_instantiation)
+    const data::file_location& point_of_instantiation,
+    double initial_time_stamp)
 {
   edge_descriptor edge;
   bool inserted;
@@ -66,6 +67,9 @@ metaprogram::edge_descriptor metaprogram::add_edge(
 
   get_edge_property(edge).kind = kind;
   get_edge_property(edge).point_of_instantiation = point_of_instantiation;
+
+  // This should be later modified when the TemplateEnd event is processed
+  get_edge_property(edge).time_taken = initial_time_stamp;
 
   return edge;
 }

--- a/lib/core/metaprogram.cpp
+++ b/lib/core/metaprogram.cpp
@@ -76,6 +76,10 @@ metaprogram::edge_descriptor metaprogram::add_edge(
   return edge;
 }
 
+void metaprogram::set_full_time_taken(double time_taken) {
+  full_time_taken = time_taken;
+}
+
 bool metaprogram::is_empty() const {
   return get_num_vertices() == 1; // 1 is the <root> vertex
 }
@@ -357,7 +361,15 @@ data::frame metaprogram::to_frame(const edge_descriptor& e_) const
     case mode_t::full:
       return data::frame(t);
     case mode_t::profile:
-      return data::frame(t, ep.point_of_instantiation, ep.kind, ep.time_taken);
+      double ratio = [&] {
+        if (full_time_taken <= 0.0) {
+          return 1.0;
+        } else {
+          return ep.time_taken / full_time_taken;
+        }
+      }();
+      return data::frame(
+        t, ep.point_of_instantiation, ep.kind, ep.time_taken, ratio);
   };
   // unreachable
   assert(false);

--- a/lib/core/metaprogram_builder.cpp
+++ b/lib/core/metaprogram_builder.cpp
@@ -41,6 +41,10 @@ void metaprogram_builder::handle_template_begin(
   auto edge =
     mp.add_edge(top_vertex, vertex, kind, point_of_instantiation, time_stamp);
   edge_stack.push(edge);
+
+  if (first_time_stamp <= 0.0) {
+    first_time_stamp = time_stamp;
+  }
 }
 
 void metaprogram_builder::handle_template_end(double time_stamp) {
@@ -52,13 +56,16 @@ void metaprogram_builder::handle_template_end(double time_stamp) {
   initial_time_stamp = time_stamp - initial_time_stamp;
 
   edge_stack.pop();
+
+  last_time_stamp = time_stamp;
 }
 
-const metaprogram& metaprogram_builder::get_metaprogram() const {
+const metaprogram& metaprogram_builder::get_metaprogram() {
   if (!edge_stack.empty()) {
     throw exception(
         "Some Templight TemplateEnd events are missing");
   }
+  mp.set_full_time_taken(last_time_stamp - first_time_stamp);
   return mp;
 }
 

--- a/lib/core/metaprogram_builder.cpp
+++ b/lib/core/metaprogram_builder.cpp
@@ -22,10 +22,10 @@
 namespace metashell {
 
 metaprogram_builder::metaprogram_builder(
-    bool full_mode,
+    metaprogram::mode_t mode,
     const std::string& root_name,
     const data::type_or_error& evaluation_result) :
-  mp(full_mode, root_name, evaluation_result)
+  mp(mode, root_name, evaluation_result)
 {}
 
 void metaprogram_builder::handle_template_begin(

--- a/lib/core/metaprogram_builder.cpp
+++ b/lib/core/metaprogram_builder.cpp
@@ -31,26 +31,31 @@ metaprogram_builder::metaprogram_builder(
 void metaprogram_builder::handle_template_begin(
   data::instantiation_kind kind,
   const std::string& context,
-  const data::file_location& point_of_instantiation)
+  const data::file_location& point_of_instantiation,
+  double time_stamp)
 {
   vertex_descriptor vertex = add_vertex(context);
-  vertex_descriptor top_vertex =
-    vertex_stack.empty() ? mp.get_root_vertex() : vertex_stack.top();
+  vertex_descriptor top_vertex = edge_stack.empty() ?
+    mp.get_root_vertex() : mp.get_target(edge_stack.top());
 
-  mp.add_edge(top_vertex, vertex, kind, point_of_instantiation);
-  vertex_stack.push(vertex);
+  auto edge =
+    mp.add_edge(top_vertex, vertex, kind, point_of_instantiation, time_stamp);
+  edge_stack.push(edge);
 }
 
-void metaprogram_builder::handle_template_end() {
-  if (vertex_stack.empty()) {
+void metaprogram_builder::handle_template_end(double time_stamp) {
+  if (edge_stack.empty()) {
     throw exception(
         "Mismatched Templight TemplateBegin and TemplateEnd events");
   }
-  vertex_stack.pop();
+  auto& initial_time_stamp = mp.get_edge_property(edge_stack.top()).time_taken;
+  initial_time_stamp = time_stamp - initial_time_stamp;
+
+  edge_stack.pop();
 }
 
 const metaprogram& metaprogram_builder::get_metaprogram() const {
-  if (!vertex_stack.empty()) {
+  if (!edge_stack.empty()) {
     throw exception(
         "Some Templight TemplateEnd events are missing");
   }

--- a/lib/core/metaprogram_parse_trace.cpp
+++ b/lib/core/metaprogram_parse_trace.cpp
@@ -57,12 +57,12 @@ data::instantiation_kind instantiation_kind_from_protobuf(int kind) {
 
 metaprogram metaprogram::create_from_protobuf_stream(
     std::istream& stream,
-    bool full_mode,
+    mode_t mode,
     const std::string& root_name,
     const data::type_or_error& evaluation_result)
 {
 
-  metaprogram_builder builder(full_mode, root_name, evaluation_result);
+  metaprogram_builder builder(mode, root_name, evaluation_result);
   templight::ProtobufReader reader;
   reader.startOnBuffer(stream);
   while (reader.LastChunk != templight::ProtobufReader::EndOfFile) {
@@ -97,12 +97,12 @@ metaprogram metaprogram::create_from_protobuf_stream(
 
 metaprogram metaprogram::create_from_protobuf_string(
     const std::string& string,
-    bool full_mode,
+    mode_t mode,
     const std::string& root_name,
     const data::type_or_error& evaluation_result)
 {
   std::istringstream ss(string);
-  return create_from_protobuf_stream(ss, full_mode, root_name, evaluation_result);
+  return create_from_protobuf_stream(ss, mode, root_name, evaluation_result);
 }
 
 }

--- a/lib/core/metaprogram_parse_trace.cpp
+++ b/lib/core/metaprogram_parse_trace.cpp
@@ -74,12 +74,16 @@ metaprogram metaprogram::create_from_protobuf_stream(
               instantiation_kind_from_protobuf(begin_entry.InstantiationKind),
               begin_entry.Name,
               data::file_location(
-                begin_entry.FileName, begin_entry.Line, begin_entry.Column));
+                begin_entry.FileName, begin_entry.Line, begin_entry.Column),
+              begin_entry.TimeStamp);
           break;
         }
       case templight::ProtobufReader::EndEntry:
-        builder.handle_template_end();
-        break;
+        {
+          auto end_entry = reader.LastEndEntry;
+          builder.handle_template_end(end_entry.TimeStamp);
+          break;
+        }
       case templight::ProtobufReader::EndOfFile:
       case templight::ProtobufReader::Other:
       case templight::ProtobufReader::Header:

--- a/lib/core/metashell.cpp
+++ b/lib/core/metashell.cpp
@@ -144,6 +144,26 @@ result metashell::validate_code(
   }
 }
 
+result metashell::run_clang(
+  const std::string& clang_path_,
+  std::vector<std::string> clang_args_,
+  const std::string& input_,
+  logger* logger_
+)
+{
+  clang_args_.push_back("-"); //Compile from stdin
+
+  const just::process::output output =
+    clang_binary(clang_path_, logger_).run(clang_args_, input_);
+
+  if (output.exit_code() != 0) {
+    return result{false, "", output.standard_error(), ""};
+  }
+
+  return result{
+    true, get_type_from_ast_string(output.standard_output()), "", ""};
+}
+
 result metashell::eval_tmp_formatted(
   const iface::environment& env_,
   const std::string& tmp_exp_,
@@ -187,21 +207,11 @@ result metashell::eval_tmp(
   const config& config_,
   logger* logger_)
 {
-  auto clang_args = env_.clang_arguments();
-  clang_args.push_back("-"); //Compile from stdin
-
-  const just::process::output output =
-    clang_binary(config_.clang_path, logger_).run(
-        clang_args,
-        env_.get_appended(
-          "::metashell::impl::wrap< " + tmp_exp_ + " > __metashell_v;\n"));
-
-  if (output.exit_code() != 0) {
-    return result{false, "", output.standard_error(), ""};
-  }
-
-  return result{
-    true, get_type_from_ast_string(output.standard_output()), "", ""};
+  return run_clang(
+    config_.clang_path, env_.clang_arguments(),
+    env_.get_appended(
+      "::metashell::impl::wrap< " + tmp_exp_ + " > __metashell_v;\n"),
+    logger_);
 }
 
 namespace

--- a/lib/core/metashell.cpp
+++ b/lib/core/metashell.cpp
@@ -213,6 +213,23 @@ result metashell::eval_tmp(
     true, get_type_from_ast_string(output.standard_output()), "", ""};
 }
 
+result metashell::eval_environment(
+  const iface::environment& env_,
+  const config& config_,
+  logger* logger_)
+{
+  const just::process::output output = run_clang(
+    config_.clang_path,
+    env_.clang_arguments(),
+    env_.get(),
+    logger_);
+
+  if (output.exit_code() != 0) {
+    return result{false, "", output.standard_error(), ""};
+  }
+  return result{true, "", "", ""};
+}
+
 namespace
 {
   std::pair<std::string, std::string> find_completion_start(

--- a/lib/core/metashell.cpp
+++ b/lib/core/metashell.cpp
@@ -67,7 +67,18 @@ namespace
     return t;
   }
 
-}
+  just::process::output run_clang(
+    const std::string& clang_path_,
+    std::vector<std::string> clang_args_,
+    const std::string& input_,
+    logger* logger_
+  )
+  {
+    clang_args_.push_back("-"); //Compile from stdin
+
+    return clang_binary(clang_path_, logger_).run(clang_args_, input_);
+  }
+} // anonymous namespace
 
 std::string metashell::repair_type_string(const std::string& type) {
   boost::regex bool_regex(
@@ -144,26 +155,6 @@ result metashell::validate_code(
   }
 }
 
-result metashell::run_clang(
-  const std::string& clang_path_,
-  std::vector<std::string> clang_args_,
-  const std::string& input_,
-  logger* logger_
-)
-{
-  clang_args_.push_back("-"); //Compile from stdin
-
-  const just::process::output output =
-    clang_binary(clang_path_, logger_).run(clang_args_, input_);
-
-  if (output.exit_code() != 0) {
-    return result{false, "", output.standard_error(), ""};
-  }
-
-  return result{
-    true, get_type_from_ast_string(output.standard_output()), "", ""};
-}
-
 result metashell::eval_tmp_formatted(
   const iface::environment& env_,
   const std::string& tmp_exp_,
@@ -207,11 +198,19 @@ result metashell::eval_tmp(
   const config& config_,
   logger* logger_)
 {
-  return run_clang(
-    config_.clang_path, env_.clang_arguments(),
+  const just::process::output output = run_clang(
+    config_.clang_path,
+    env_.clang_arguments(),
     env_.get_appended(
       "::metashell::impl::wrap< " + tmp_exp_ + " > __metashell_v;\n"),
     logger_);
+
+  if (output.exit_code() != 0) {
+    return result{false, "", output.standard_error(), ""};
+  }
+
+  return result{
+    true, get_type_from_ast_string(output.standard_output()), "", ""};
 }
 
 namespace

--- a/lib/core/null_json_writer.cpp
+++ b/lib/core/null_json_writer.cpp
@@ -28,6 +28,11 @@ void null_json_writer::int_(int)
   // throw away
 }
 
+void null_json_writer::double_(double)
+{
+  // throw away
+}
+
 void null_json_writer::start_object()
 {
   // throw away

--- a/lib/core/pager.cpp
+++ b/lib/core/pager.cpp
@@ -27,6 +27,12 @@ namespace metashell {
 pager::pager(iface::console& console) : console_(console) {}
 
 void pager::show(const data::colored_string& string) {
+  console_.show(string);
+
+  if (show_all) {
+    return;
+  }
+
   int width = console_.width();
 
   for (char ch : string.get_string()) {
@@ -41,20 +47,35 @@ void pager::show(const data::colored_string& string) {
       }
     }
   }
-
-  console_.show(string);
 }
 
-void pager::new_line() {
+bool pager::new_line() {
+  console_.new_line();
+
+  if (show_all) {
+    return true;
+  }
+
   chars_in_current_line = 0;
   ++lines_in_current_page;
-
-  console_.new_line();
 
   int height = console_.height();
   if (height <= lines_in_current_page + 1) {
     lines_in_current_page = 0;
+
+    auto answer = console_.ask_for_continuation();
+
+    switch (answer) {
+      case iface::console::user_answer::show_all:
+        show_all = true;
+        return true;
+      case iface::console::user_answer::quit:
+        return false;
+      case iface::console::user_answer::next_page:
+        return true;
+    }
   }
+  return true;
 }
 
 } // namespace metashell

--- a/lib/core/pager.cpp
+++ b/lib/core/pager.cpp
@@ -16,16 +16,45 @@
 
 #include <metashell/pager.hpp>
 
+#include <cassert>
+
+#include <boost/range/algorithm/count.hpp>
+
+#include <iostream>
+
 namespace metashell {
 
 pager::pager(iface::console& console) : console_(console) {}
 
 void pager::show(const data::colored_string& string) {
+  int width = console_.width();
+
+  for (char ch : string.get_string()) {
+    if (ch == '\n') {
+      ++lines_in_current_page;
+      chars_in_current_line = 0;
+    } else {
+      ++chars_in_current_line;
+      if (chars_in_current_line > width) {
+        ++lines_in_current_page;
+        chars_in_current_line = 0;
+      }
+    }
+  }
+
   console_.show(string);
 }
 
 void pager::new_line() {
+  chars_in_current_line = 0;
+  ++lines_in_current_page;
+
   console_.new_line();
+
+  int height = console_.height();
+  if (height <= lines_in_current_page + 1) {
+    lines_in_current_page = 0;
+  }
 }
 
 } // namespace metashell

--- a/lib/core/pager.cpp
+++ b/lib/core/pager.cpp
@@ -1,0 +1,31 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell/pager.hpp>
+
+namespace metashell {
+
+pager::pager(iface::console& console) : console_(console) {}
+
+void pager::show(const data::colored_string& string) {
+  console_.show(string);
+}
+
+void pager::new_line() {
+  console_.new_line();
+}
+
+} // namespace metashell

--- a/lib/core/rapid_json_writer.cpp
+++ b/lib/core/rapid_json_writer.cpp
@@ -39,6 +39,11 @@ void rapid_json_writer::int_(int value_)
   _writer.Int(value_);
 }
 
+void rapid_json_writer::double_(double value_)
+{
+  _writer.Double(value_);
+}
+
 void rapid_json_writer::start_object()
 {
   _writer.StartObject();

--- a/lib/core/stdout_console.cpp
+++ b/lib/core/stdout_console.cpp
@@ -43,6 +43,7 @@ iface::console::user_answer stdout_console::ask_for_continuation()
     std::cout << "Next page (RETURN), Show all (a), Quit (q): ";
 
     if (!std::getline(std::cin, line)) {
+      new_line();
       return iface::console::user_answer::quit;
     }
     if (line.empty()) {

--- a/lib/core/stdout_console.cpp
+++ b/lib/core/stdout_console.cpp
@@ -36,6 +36,11 @@ void stdout_console::new_line()
   std::cout << std::endl;
 }
 
+iface::console::user_answer stdout_console::ask_for_continuation()
+{
+  return iface::console::user_answer::show_all;
+}
+
 int stdout_console::width() const
 {
 #ifdef _WIN32

--- a/lib/core/stdout_console.cpp
+++ b/lib/core/stdout_console.cpp
@@ -38,7 +38,23 @@ void stdout_console::new_line()
 
 iface::console::user_answer stdout_console::ask_for_continuation()
 {
-  return iface::console::user_answer::show_all;
+  std::string line;
+  while (true) {
+    std::cout << "Next page (RETURN), Show all (a), Quit (q): ";
+
+    if (!std::getline(std::cin, line)) {
+      return iface::console::user_answer::quit;
+    }
+    if (line.empty()) {
+      return iface::console::user_answer::next_page;
+    }
+    if (line == "a" || line == "A") {
+      return iface::console::user_answer::show_all;
+    }
+    if (line == "q" || line == "Q") {
+      return iface::console::user_answer::quit;
+    }
+  }
 }
 
 int stdout_console::width() const

--- a/lib/core/stdout_console.cpp
+++ b/lib/core/stdout_console.cpp
@@ -50,3 +50,16 @@ int stdout_console::width() const
 #endif
 }
 
+int stdout_console::height() const
+{
+#ifdef _WIN32
+    CONSOLE_SCREEN_BUFFER_INFO info;
+
+    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
+    return info.srWindow.Bottom - info.srWindow.Top + 1;
+#else
+    struct winsize w;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    return w.ws_row;
+#endif
+}

--- a/lib/core/stream_console.cpp
+++ b/lib/core/stream_console.cpp
@@ -40,3 +40,7 @@ int stream_console::width() const
   return std::numeric_limits<int>::max();
 }
 
+int stream_console::height() const
+{
+  return std::numeric_limits<int>::max();
+}

--- a/lib/core/stream_console.cpp
+++ b/lib/core/stream_console.cpp
@@ -35,6 +35,11 @@ void stream_console::new_line()
   *_s << std::endl;
 }
 
+iface::console::user_answer stream_console::ask_for_continuation()
+{
+  return iface::console::user_answer::show_all;
+}
+
 int stream_console::width() const
 {
   return std::numeric_limits<int>::max();

--- a/lib/data/frame.cpp
+++ b/lib/data/frame.cpp
@@ -22,8 +22,7 @@
 
 using namespace metashell::data;
 
-frame::frame(const type& name_,
-  boost::optional<double> time_taken) : _name(name_), _time_taken(time_taken) {}
+frame::frame(const type& name_) : _name(name_) {}
 
 frame::frame(
     const type& name_,

--- a/lib/data/frame.cpp
+++ b/lib/data/frame.cpp
@@ -22,15 +22,18 @@
 
 using namespace metashell::data;
 
-frame::frame(const type& name_) : _name(name_) {}
+frame::frame(const type& name_,
+  boost::optional<double> time_taken) : _name(name_), _time_taken(time_taken) {}
 
 frame::frame(
     const type& name_,
     const file_location& point_of_instantiation_,
-    instantiation_kind kind_) :
+    instantiation_kind kind_,
+    boost::optional<double> time_taken) :
   _name(name_),
   _point_of_instantiation(point_of_instantiation_),
-  _kind(kind_)
+  _kind(kind_),
+  _time_taken(time_taken)
 {}
 
 const type& frame::name() const
@@ -42,6 +45,11 @@ bool frame::is_full() const
 {
   assert(bool(_kind) == bool(_point_of_instantiation));
   return bool(_kind);
+}
+
+bool frame::is_profiled() const
+{
+  return bool(_time_taken);
 }
 
 instantiation_kind frame::kind() const
@@ -56,6 +64,12 @@ const file_location& frame::point_of_instantiation() const
   return *_point_of_instantiation;
 }
 
+double frame::time_taken() const
+{
+  assert(is_profiled());
+  return *_time_taken;
+}
+
 
 std::ostream& metashell::data::operator<<(std::ostream& o_, const frame& f_)
 {
@@ -63,6 +77,10 @@ std::ostream& metashell::data::operator<<(std::ostream& o_, const frame& f_)
   if (f_.is_full())
   {
     o_ << ", " << f_.point_of_instantiation() << ", " << f_.kind();
+  }
+  if (f_.is_profiled())
+  {
+    o_ << ", " << f_.time_taken() << "s";
   }
   o_ << ")";
   return o_;
@@ -77,6 +95,9 @@ bool metashell::data::operator==(const frame& a_, const frame& b_)
         (a_.kind() == b_.kind()
         // TODO commented out, because I don't want to include this information
         // into the UTs.
-        /*&& a_.point_of_instantiation() == b_.point_of_instantiation()*/));
+        /*&& a_.point_of_instantiation() == b_.point_of_instantiation()*/))
+    && a_.is_profiled() == b_.is_profiled()
+    && (!a_.is_profiled() ||
+        (a_.time_taken() == b_.time_taken()));
 }
 

--- a/lib/data/frame.cpp
+++ b/lib/data/frame.cpp
@@ -28,11 +28,13 @@ frame::frame(
     const type& name_,
     const file_location& point_of_instantiation_,
     instantiation_kind kind_,
-    boost::optional<double> time_taken) :
+    boost::optional<double> time_taken,
+    boost::optional<double> time_taken_ratio) :
   _name(name_),
   _point_of_instantiation(point_of_instantiation_),
   _kind(kind_),
-  _time_taken(time_taken)
+  _time_taken(time_taken),
+  _time_taken_ratio(time_taken_ratio)
 {}
 
 const type& frame::name() const
@@ -48,6 +50,7 @@ bool frame::is_full() const
 
 bool frame::is_profiled() const
 {
+  assert(bool(_time_taken) == bool(_time_taken_ratio));
   return bool(_time_taken);
 }
 
@@ -67,6 +70,12 @@ double frame::time_taken() const
 {
   assert(is_profiled());
   return *_time_taken;
+}
+
+double frame::time_taken_ratio() const
+{
+  assert(is_profiled());
+  return *_time_taken_ratio;
 }
 
 
@@ -97,6 +106,7 @@ bool metashell::data::operator==(const frame& a_, const frame& b_)
         /*&& a_.point_of_instantiation() == b_.point_of_instantiation()*/))
     && a_.is_profiled() == b_.is_profiled()
     && (!a_.is_profiled() ||
-        (a_.time_taken() == b_.time_taken()));
+        (a_.time_taken() == b_.time_taken()
+         && a_.time_taken_ratio() == b_.time_taken_ratio()));
 }
 

--- a/lib/data/type_or_error.cpp
+++ b/lib/data/type_or_error.cpp
@@ -21,9 +21,15 @@
 
 namespace metashell { namespace data {
 
+type_or_error::type_or_error() : data(boost::blank{}) {}
+
 type_or_error::type_or_error(const type_type& t) : data(t) {}
 
 type_or_error::type_or_error(const error_type& e) : data(e) {}
+
+type_or_error type_or_error::make_none() {
+  return type_or_error();
+}
 
 type_or_error type_or_error::make_type(const type_type& t) {
   return type_or_error(t);
@@ -31,6 +37,10 @@ type_or_error type_or_error::make_type(const type_type& t) {
 
 type_or_error type_or_error::make_error(const error_type& e) {
   return type_or_error(e);
+}
+
+bool type_or_error::is_none() const {
+  return boost::get<boost::blank>(&data) != nullptr;
 }
 
 bool type_or_error::is_type() const {
@@ -58,8 +68,10 @@ bool type_or_error::operator==(const type_or_error& other) const {
 std::ostream& operator<<(std::ostream& os, const type_or_error& te) {
   if (te.is_type()) {
     os << "type[" << te.get_type() << "]";
-  } else {
+  } else if (te.is_error()) {
     os << "error[" << te.get_error() << "]";
+  } else {
+    os << "none[]";
   }
   return os;
 }

--- a/test/system/app/mdb/test_step.cpp
+++ b/test/system/app/mdb/test_step.cpp
@@ -324,6 +324,81 @@ JUST_TEST_CASE(test_mdb_step_over_the_whole_metaprogram_multiple_steps) {
   JUST_ASSERT_EQUAL(type("int_<55>"), *i++);
 }
 
+JUST_TEST_CASE(test_mdb_step_over_environment_multiple_steps) {
+  std::vector<json_string> commands = {
+    command(
+      fibonacci_mp +
+      "int_<fib<5>::value> x;"
+      "int_<fib<6>::value> y;"
+    ),
+    command("#msh mdb -")
+  };
+  for (auto i = 0; i < 19; ++i) {
+    commands.push_back(command("step"));
+  }
+
+  const auto r = run_metashell(commands);
+
+  auto i = r.begin() + 4;
+
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<5>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<3>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<1>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<2>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<0>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<1>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<4>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<2>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<3>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<5>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("int_<5>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("int_<5>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<6>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<4>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<5>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("fib<6>"), instantiation_kind::memoization), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("int_<8>"), instantiation_kind::template_instantiation), *i);
+  i += 2;
+  JUST_ASSERT_EQUAL(
+      frame(type("int_<8>"), instantiation_kind::memoization), *i);
+  i += 2;
+
+  JUST_ASSERT_EQUAL(raw_text("Metaprogram finished"), *i++);
+}
+
 JUST_TEST_CASE(
     test_mdb_step_over_the_whole_metaprogram_multiple_steps_in_full_mode)
 {

--- a/test/unit/mock_console.cpp
+++ b/test/unit/mock_console.cpp
@@ -18,8 +18,9 @@
 
 using namespace metashell;
 
-mock_console::mock_console(int width_) :
-  _width(width_)
+mock_console::mock_console(int width_, int height_) :
+  _width(width_),
+  _height(height_)
 {}
 
 void mock_console::show(const metashell::data::colored_string& s_)
@@ -37,6 +38,11 @@ int mock_console::width() const
   return _width;
 }
 
+int mock_console::height() const
+{
+  return _height;
+}
+
 void mock_console::clear()
 {
   _content.clear();
@@ -45,6 +51,11 @@ void mock_console::clear()
 void mock_console::set_width(int width_)
 {
   _width = width_;
+}
+
+void mock_console::set_height(int height_)
+{
+  _height = height_;
 }
 
 const metashell::data::colored_string& mock_console::content() const

--- a/test/unit/mock_console.cpp
+++ b/test/unit/mock_console.cpp
@@ -45,12 +45,19 @@ int mock_console::height() const
 
 iface::console::user_answer mock_console::ask_for_continuation()
 {
-  return iface::console::user_answer::show_all;
+  ++_ask_for_continuation_count;
+  return _continuation_answer;
 }
 
 void mock_console::clear()
 {
   _content.clear();
+  _ask_for_continuation_count = 0;
+}
+
+void mock_console::set_continiation_answer(user_answer answer)
+{
+  _continuation_answer = answer;
 }
 
 void mock_console::set_width(int width_)
@@ -66,5 +73,10 @@ void mock_console::set_height(int height_)
 const metashell::data::colored_string& mock_console::content() const
 {
   return _content;
+}
+
+int mock_console::ask_for_continuation_count() const
+{
+  return _ask_for_continuation_count;
 }
 

--- a/test/unit/mock_console.cpp
+++ b/test/unit/mock_console.cpp
@@ -43,6 +43,11 @@ int mock_console::height() const
   return _height;
 }
 
+iface::console::user_answer mock_console::ask_for_continuation()
+{
+  return iface::console::user_answer::show_all;
+}
+
 void mock_console::clear()
 {
   _content.clear();

--- a/test/unit/mock_console.hpp
+++ b/test/unit/mock_console.hpp
@@ -36,12 +36,17 @@ public:
   virtual int height() const override;
 
   void clear();
+  void set_continiation_answer(user_answer answer);
   void set_width(int width_);
   void set_height(int width_);
 
   const metashell::data::colored_string& content() const;
+  int ask_for_continuation_count() const;
 private:
   metashell::data::colored_string _content;
+  int _ask_for_continuation_count = 0;
+
+  user_answer _continuation_answer = user_answer::show_all;
   int _width;
   int _height;
 };

--- a/test/unit/mock_console.hpp
+++ b/test/unit/mock_console.hpp
@@ -30,6 +30,8 @@ public:
   virtual void show(const metashell::data::colored_string& s_) override;
   virtual void new_line() override;
 
+  virtual user_answer ask_for_continuation() override;
+
   virtual int width() const override;
   virtual int height() const override;
 

--- a/test/unit/mock_console.hpp
+++ b/test/unit/mock_console.hpp
@@ -19,23 +19,29 @@
 
 #include <metashell/iface/console.hpp>
 
+#include <limits>
+
 class mock_console : public metashell::iface::console
 {
 public:
-  explicit mock_console(int width_ = 80);
+  explicit mock_console(
+    int width_ = 80, int height_ = std::numeric_limits<int>::max());
 
   virtual void show(const metashell::data::colored_string& s_) override;
   virtual void new_line() override;
 
   virtual int width() const override;
+  virtual int height() const override;
 
   void clear();
   void set_width(int width_);
+  void set_height(int width_);
 
   const metashell::data::colored_string& content() const;
 private:
   metashell::data::colored_string _content;
   int _width;
+  int _height;
 };
 
 #endif

--- a/test/unit/mock_json_writer.cpp
+++ b/test/unit/mock_json_writer.cpp
@@ -26,6 +26,11 @@ void mock_json_writer::int_(int value_)
   _calls.push_back("int " + std::to_string(value_));
 }
 
+void mock_json_writer::double_(double value_)
+{
+  _calls.push_back("double " + std::to_string(value_));
+}
+
 void mock_json_writer::start_object()
 {
   _calls.push_back("start_object");

--- a/test/unit/mock_json_writer.hpp
+++ b/test/unit/mock_json_writer.hpp
@@ -27,6 +27,7 @@ class mock_json_writer : public metashell::iface::json_writer
 public:
   virtual void string(const std::string& value_) override;
   virtual void int_(int value_) override;
+  virtual void double_(double value) override;
 
   virtual void start_object() override;
   virtual void key(const std::string& key_) override;

--- a/test/unit/test_mdb_evaluate.cpp
+++ b/test/unit/test_mdb_evaluate.cpp
@@ -60,6 +60,22 @@ JUST_TEST_CASE(test_mdb_evaluate_fib_10) {
 #endif
 
 #ifndef METASHELL_DISABLE_TEMPLIGHT_TESTS
+JUST_TEST_CASE(test_mdb_evaluate_empty_environment) {
+  in_memory_displayer d;
+  mdb_test_shell sh;
+
+  sh.line_available("evaluate -", d);
+
+  JUST_ASSERT_EQUAL_CONTAINER({"Metaprogram started"}, d.raw_texts());
+  JUST_ASSERT(sh.has_metaprogram());
+  JUST_ASSERT_EQUAL(
+    sh.get_metaprogram().get_evaluation_result(),
+    data::type_or_error::make_none()
+  );
+}
+#endif
+
+#ifndef METASHELL_DISABLE_TEMPLIGHT_TESTS
 JUST_TEST_CASE(test_mdb_evaluate_no_arguments_no_evaluation) {
   in_memory_displayer d;
   mdb_test_shell sh;
@@ -170,6 +186,32 @@ JUST_TEST_CASE(
         first_state.discovered.begin(),
         first_state.discovered.end(),
         second_state.discovered.begin()));
+}
+#endif
+
+#ifndef METASHELL_DISABLE_TEMPLIGHT_TESTS
+JUST_TEST_CASE(test_mdb_reevaluate_environment) {
+  in_memory_displayer d;
+  mdb_test_shell sh;
+
+  sh.line_available("evaluate -", d);
+
+  JUST_ASSERT_EQUAL_CONTAINER({"Metaprogram started"}, d.raw_texts());
+  JUST_ASSERT(sh.has_metaprogram());
+  JUST_ASSERT_EQUAL(
+    sh.get_metaprogram().get_evaluation_result(),
+    data::type_or_error::make_none()
+  );
+
+  d.clear();
+
+  sh.line_available("evaluate", d);
+  JUST_ASSERT_EQUAL_CONTAINER({"Metaprogram started"}, d.raw_texts());
+  JUST_ASSERT(sh.has_metaprogram());
+  JUST_ASSERT_EQUAL(
+    sh.get_metaprogram().get_evaluation_result(),
+    data::type_or_error::make_none()
+  );
 }
 #endif
 

--- a/test/unit/test_metaprogram.cpp
+++ b/test/unit/test_metaprogram.cpp
@@ -92,7 +92,7 @@ JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex) {
   metaprogram::edge_descriptor edge_root_a =
     mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
-        data::file_location("foo.cpp", 10, 20));
+        data::file_location("foo.cpp", 10, 20), 10.0);
 
   JUST_ASSERT_EQUAL(mp.get_num_vertices(), 2u);
   JUST_ASSERT_EQUAL(mp.get_num_edges(), 1u);
@@ -142,11 +142,11 @@ JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex_parallel_edge) {
   metaprogram::edge_descriptor edge_root_a_ti =
     mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
-        data::file_location("bar.cpp", 20, 10));
+        data::file_location("bar.cpp", 20, 10), 10.0);
   metaprogram::edge_descriptor edge_root_a_me =
     mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::memoization,
-        data::file_location("foobar.cpp", 21, 11));
+        data::file_location("foobar.cpp", 21, 11), 10.0);
 
   JUST_ASSERT_EQUAL(mp.get_num_vertices(), 2u);
   JUST_ASSERT_EQUAL(mp.get_num_edges(), 2u);
@@ -208,7 +208,7 @@ JUST_TEST_CASE(test_metaprogram_step_back_with_single_non_root_vertex) {
   metaprogram::edge_descriptor edge_root_a =
     mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
-      data::file_location("foobar.cpp", 21, 11));
+      data::file_location("foobar.cpp", 21, 11), 10.0);
 
   JUST_ASSERT_EQUAL(mp.get_num_vertices(), 2u);
   JUST_ASSERT_EQUAL(mp.get_num_edges(), 1u);
@@ -258,11 +258,11 @@ JUST_TEST_CASE(
   metaprogram::edge_descriptor edge_root_a_ti =
     mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
-        data::file_location("xx.cpp", 1, 2));
+        data::file_location("xx.cpp", 1, 2), 10.0);
   metaprogram::edge_descriptor edge_root_a_me =
     mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::memoization,
-        data::file_location("yy.cpp", 1, 2));
+        data::file_location("yy.cpp", 1, 2), 10.0);
 
   JUST_ASSERT_EQUAL(mp.get_num_vertices(), 2u);
   JUST_ASSERT_EQUAL(mp.get_num_edges(), 2u);

--- a/test/unit/test_metaprogram.cpp
+++ b/test/unit/test_metaprogram.cpp
@@ -346,6 +346,13 @@ JUST_TEST_CASE(
   JUST_ASSERT(!mp.is_finished());
 }
 
+JUST_TEST_CASE(test_metaprogram_constructor_normal_mode) {
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
+
+  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
+}
+
 JUST_TEST_CASE(test_metaprogram_constructor_full_mode) {
   metaprogram mp(metaprogram::mode_t::full,
       "some_type", data::type_or_error(data::type("the_result_type")));
@@ -353,9 +360,9 @@ JUST_TEST_CASE(test_metaprogram_constructor_full_mode) {
   JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::full);
 }
 
-JUST_TEST_CASE(test_metaprogram_constructor_normal_mode) {
-  metaprogram mp(metaprogram::mode_t::normal,
+JUST_TEST_CASE(test_metaprogram_constructor_profile_mode) {
+  metaprogram mp(metaprogram::mode_t::profile,
       "some_type", data::type_or_error(data::type("the_result_type")));
 
-  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
+  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::profile);
 }

--- a/test/unit/test_metaprogram.cpp
+++ b/test/unit/test_metaprogram.cpp
@@ -88,9 +88,8 @@ JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex) {
 
   JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
 
-  metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
-  metaprogram::edge_descriptor edge_root_a =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto vertex_a = mp.add_vertex("A");
+  auto edge_root_a = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
         data::file_location("foo.cpp", 10, 20), 10.0);
 
@@ -138,13 +137,11 @@ JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex_parallel_edge) {
 
   JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
 
-  metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
-  metaprogram::edge_descriptor edge_root_a_ti =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto vertex_a = mp.add_vertex("A");
+  auto edge_root_a_ti = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
         data::file_location("bar.cpp", 20, 10), 10.0);
-  metaprogram::edge_descriptor edge_root_a_me =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto edge_root_a_me = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::memoization,
         data::file_location("foobar.cpp", 21, 11), 10.0);
 
@@ -204,9 +201,8 @@ JUST_TEST_CASE(test_metaprogram_step_back_with_single_non_root_vertex) {
   metaprogram mp(metaprogram::mode_t::normal,
       "some_type", data::type_or_error(data::type("the_result_type")));
 
-  metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
-  metaprogram::edge_descriptor edge_root_a =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto vertex_a = mp.add_vertex("A");
+  auto edge_root_a = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
       data::file_location("foobar.cpp", 21, 11), 10.0);
 
@@ -254,13 +250,11 @@ JUST_TEST_CASE(
   metaprogram mp(metaprogram::mode_t::normal,
       "some_type", data::type_or_error(data::type("the_result_type")));
 
-  metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
-  metaprogram::edge_descriptor edge_root_a_ti =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto vertex_a = mp.add_vertex("A");
+  auto edge_root_a_ti = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
         data::file_location("xx.cpp", 1, 2), 10.0);
-  metaprogram::edge_descriptor edge_root_a_me =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto edge_root_a_me = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::memoization,
         data::file_location("yy.cpp", 1, 2), 10.0);
 
@@ -353,12 +347,10 @@ JUST_TEST_CASE(test_metaprogram_step_sorting_in_profile_mode) {
   auto vertex_a = mp.add_vertex("A");
   auto vertex_b = mp.add_vertex("B");
 
-  auto edge_root_a_ti =
-    mp.add_edge(mp.get_root_vertex(), vertex_a,
+  auto edge_root_a_ti = mp.add_edge(mp.get_root_vertex(), vertex_a,
         data::instantiation_kind::template_instantiation,
         data::file_location("xx.cpp", 1, 2), 10.0);
-  auto edge_root_b_ti =
-    mp.add_edge(mp.get_root_vertex(), vertex_b,
+  auto edge_root_b_ti = mp.add_edge(mp.get_root_vertex(), vertex_b,
         data::instantiation_kind::memoization,
         data::file_location("yy.cpp", 1, 2), 30.0);
 

--- a/test/unit/test_metaprogram.cpp
+++ b/test/unit/test_metaprogram.cpp
@@ -49,8 +49,8 @@ void assert_state_equal(
 }
 
 JUST_TEST_CASE(test_metaprogram_constructor) {
-  metaprogram mp(
-      false, "some_type", data::type_or_error(data::type("the_result_type")));
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
   JUST_ASSERT_EQUAL(
       mp.get_evaluation_result(),
@@ -83,10 +83,10 @@ JUST_TEST_CASE(test_metaprogram_constructor) {
 }
 
 JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex) {
-  metaprogram mp(
-      false, "some_type", data::type_or_error(data::type("the_result_type")));
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
-  JUST_ASSERT(!mp.is_in_full_mode());
+  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
 
   metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
   metaprogram::edge_descriptor edge_root_a =
@@ -133,10 +133,10 @@ JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex) {
 }
 
 JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex_parallel_edge) {
-  metaprogram mp(
-      false, "some_type", data::type_or_error(data::type("the_result_type")));
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
-  JUST_ASSERT(!mp.is_in_full_mode());
+  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
 
   metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
   metaprogram::edge_descriptor edge_root_a_ti =
@@ -201,8 +201,8 @@ JUST_TEST_CASE(test_metaprogram_with_single_non_root_vertex_parallel_edge) {
 }
 
 JUST_TEST_CASE(test_metaprogram_step_back_with_single_non_root_vertex) {
-  metaprogram mp(
-      false, "some_type", data::type_or_error(data::type("the_result_type")));
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
   metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
   metaprogram::edge_descriptor edge_root_a =
@@ -251,8 +251,8 @@ JUST_TEST_CASE(test_metaprogram_step_back_with_single_non_root_vertex) {
 JUST_TEST_CASE(
     test_metaprogram_step_back_with_single_non_root_vertex_parallel_edge)
 {
-  metaprogram mp(
-      false, "some_type", data::type_or_error(data::type("the_result_type")));
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
   metaprogram::vertex_descriptor vertex_a = mp.add_vertex("A");
   metaprogram::edge_descriptor edge_root_a_ti =
@@ -346,16 +346,16 @@ JUST_TEST_CASE(
   JUST_ASSERT(!mp.is_finished());
 }
 
-JUST_TEST_CASE(test_metaprogram_constructor_full_mode_true) {
-  metaprogram mp(
-      true, "some_type", data::type_or_error(data::type("the_result_type")));
+JUST_TEST_CASE(test_metaprogram_constructor_full_mode) {
+  metaprogram mp(metaprogram::mode_t::full,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
-  JUST_ASSERT(mp.is_in_full_mode());
+  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::full);
 }
 
-JUST_TEST_CASE(test_metaprogram_constructor_full_mode_false) {
-  metaprogram mp(
-      false, "some_type", data::type_or_error(data::type("the_result_type")));
+JUST_TEST_CASE(test_metaprogram_constructor_normal_mode) {
+  metaprogram mp(metaprogram::mode_t::normal,
+      "some_type", data::type_or_error(data::type("the_result_type")));
 
-  JUST_ASSERT(!mp.is_in_full_mode());
+  JUST_ASSERT_EQUAL(mp.get_mode(), metaprogram::mode_t::normal);
 }

--- a/test/unit/test_metaprogram_builder.cpp
+++ b/test/unit/test_metaprogram_builder.cpp
@@ -1,0 +1,199 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell/metaprogram_builder.hpp>
+
+#include <just/test.hpp>
+
+using namespace metashell;
+
+JUST_TEST_CASE(test_metaprogram_builder_normal_mode) {
+  metaprogram_builder mb(
+    metaprogram::mode_t::normal, "root_name", data::type("eval_result"));
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<A>",
+    data::file_location("file", 10, 20),
+    100.0);
+
+  mb.handle_template_end(110.0);
+
+  metaprogram mp = mb.get_metaprogram();
+
+  JUST_ASSERT_EQUAL(metaprogram::mode_t::normal, mp.get_mode());
+  JUST_ASSERT_EQUAL(2u, mp.get_num_vertices());
+  JUST_ASSERT_EQUAL(1u, mp.get_num_edges());
+
+  JUST_ASSERT(mp.is_at_start());
+
+  mp.step();
+
+  auto frame = mp.get_current_frame();
+
+  JUST_ASSERT(frame.is_full());
+  JUST_ASSERT(!frame.is_profiled());
+  JUST_ASSERT_EQUAL("type<A>", frame.name().name());
+  JUST_ASSERT_EQUAL(
+    data::instantiation_kind::template_instantiation, frame.kind());
+
+  mp.step();
+
+  JUST_ASSERT(mp.is_finished());
+}
+
+JUST_TEST_CASE(test_metaprogram_builder_full_mode) {
+  metaprogram_builder mb(
+    metaprogram::mode_t::full, "root_name", data::type("eval_result"));
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<A>",
+    data::file_location("file", 10, 20),
+    100.0);
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<B>",
+    data::file_location("file", 20, 20),
+    110.0);
+
+  mb.handle_template_end(120.0);
+
+  mb.handle_template_end(130.0);
+
+  mb.handle_template_begin(
+    data::instantiation_kind::memoization,
+    "type<A>",
+    data::file_location("file", 10, 20),
+    140.0);
+
+  mb.handle_template_end(150.0);
+
+  metaprogram mp = mb.get_metaprogram();
+
+  JUST_ASSERT_EQUAL(metaprogram::mode_t::full, mp.get_mode());
+  JUST_ASSERT_EQUAL(3u, mp.get_num_vertices());
+  JUST_ASSERT_EQUAL(3u, mp.get_num_edges());
+
+  JUST_ASSERT(mp.is_at_start());
+
+  mp.step();
+
+  {
+    auto frame = mp.get_current_frame();
+
+    JUST_ASSERT(!frame.is_full());
+    JUST_ASSERT(!frame.is_profiled());
+    JUST_ASSERT_EQUAL("type<A>", frame.name().name());
+  }
+
+  mp.step();
+
+  {
+    auto frame = mp.get_current_frame();
+
+    JUST_ASSERT(!frame.is_full());
+    JUST_ASSERT(!frame.is_profiled());
+    JUST_ASSERT_EQUAL("type<B>", frame.name().name());
+  }
+
+  mp.step();
+
+  {
+    auto frame = mp.get_current_frame();
+
+    JUST_ASSERT(!frame.is_full());
+    JUST_ASSERT(!frame.is_profiled());
+    JUST_ASSERT_EQUAL("type<A>", frame.name().name());
+  }
+
+  mp.step();
+
+  {
+    auto frame = mp.get_current_frame();
+
+    JUST_ASSERT(!frame.is_full());
+    JUST_ASSERT(!frame.is_profiled());
+    JUST_ASSERT_EQUAL("type<B>", frame.name().name());
+  }
+
+  mp.step();
+
+  JUST_ASSERT(mp.is_finished());
+
+}
+
+JUST_TEST_CASE(test_metaprogram_builder_profile_mode) {
+  metaprogram_builder mb(
+    metaprogram::mode_t::profile, "root_name", data::type("eval_result"));
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<A>",
+    data::file_location("file", 10, 20),
+    100.0);
+
+  mb.handle_template_end(110.0);
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<B>",
+    data::file_location("file", 10, 20),
+    120.0);
+
+  mb.handle_template_end(140.0);
+
+  metaprogram mp = mb.get_metaprogram();
+
+  JUST_ASSERT_EQUAL(metaprogram::mode_t::profile, mp.get_mode());
+  JUST_ASSERT_EQUAL(3u, mp.get_num_vertices());
+  JUST_ASSERT_EQUAL(2u, mp.get_num_edges());
+
+  JUST_ASSERT(mp.is_at_start());
+
+  mp.step();
+
+  {
+    auto frame = mp.get_current_frame();
+
+    JUST_ASSERT(frame.is_full());
+    JUST_ASSERT(frame.is_profiled());
+    JUST_ASSERT_EQUAL("type<B>", frame.name().name());
+    JUST_ASSERT_EQUAL(
+      data::instantiation_kind::template_instantiation, frame.kind());
+    JUST_ASSERT_EQUAL(20.0, frame.time_taken());
+    JUST_ASSERT_EQUAL(0.5, frame.time_taken_ratio());
+  }
+
+  mp.step();
+
+  {
+    auto frame = mp.get_current_frame();
+
+    JUST_ASSERT(frame.is_full());
+    JUST_ASSERT(frame.is_profiled());
+    JUST_ASSERT_EQUAL("type<A>", frame.name().name());
+    JUST_ASSERT_EQUAL(
+      data::instantiation_kind::template_instantiation, frame.kind());
+    JUST_ASSERT_EQUAL(10.0, frame.time_taken());
+    JUST_ASSERT_EQUAL(0.25, frame.time_taken_ratio());
+  }
+
+  mp.step();
+
+  JUST_ASSERT(mp.is_finished());
+}

--- a/test/unit/test_metaprogram_builder.cpp
+++ b/test/unit/test_metaprogram_builder.cpp
@@ -197,3 +197,47 @@ JUST_TEST_CASE(test_metaprogram_builder_profile_mode) {
 
   JUST_ASSERT(mp.is_finished());
 }
+
+JUST_TEST_CASE(test_metaprogram_builder_too_much_end_events_1) {
+  metaprogram_builder mb(
+    metaprogram::mode_t::normal, "root_name", data::type("eval_result"));
+
+  JUST_ASSERT_THROWS<std::exception>([&] {
+    mb.handle_template_end(100.0);
+  }).check_exception(JUST_WHAT_RETURNS(
+    "Mismatched Templight TemplateBegin and TemplateEnd events"));
+}
+
+JUST_TEST_CASE(test_metaprogram_builder_too_much_end_events_2) {
+  metaprogram_builder mb(
+    metaprogram::mode_t::normal, "root_name", data::type("eval_result"));
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<A>",
+    data::file_location("file", 10, 20),
+    100.0);
+
+  mb.handle_template_end(110.0);
+
+  JUST_ASSERT_THROWS<std::exception>([&] {
+    mb.handle_template_end(120.0);
+  }).check_exception(JUST_WHAT_RETURNS(
+    "Mismatched Templight TemplateBegin and TemplateEnd events"));
+}
+
+JUST_TEST_CASE(test_metaprogram_builder_too_few_end_events) {
+  metaprogram_builder mb(
+    metaprogram::mode_t::normal, "root_name", data::type("eval_result"));
+
+  mb.handle_template_begin(
+    data::instantiation_kind::template_instantiation,
+    "type<A>",
+    data::file_location("file", 10, 20),
+    100.0);
+
+  JUST_ASSERT_THROWS<std::exception>([&] {
+    mb.get_metaprogram();
+  }).check_exception(JUST_WHAT_RETURNS(
+    "Some Templight TemplateEnd events are missing"));
+}

--- a/test/unit/test_pager.cpp
+++ b/test/unit/test_pager.cpp
@@ -1,0 +1,207 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2015, Andras Kucsma (andras.kucsma@gmail.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell/console_displayer.hpp>
+#include <metashell/pager.hpp>
+
+#include "mock_console.hpp"
+
+#include <just/test.hpp>
+
+using namespace metashell;
+
+JUST_TEST_CASE(test_pager_one_line) {
+  mock_console c(80, 100);
+  pager p(c);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+  JUST_ASSERT_EQUAL("first\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_non_full_page) {
+  mock_console c(80, 5);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::next_page);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+  p.show("second");
+  JUST_ASSERT(p.new_line());
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+  JUST_ASSERT_EQUAL("first\nsecond\nthird\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_almost_full_page) {
+  mock_console c(80, 4);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::next_page);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("second");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("first\nsecond\nthird\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_full_page_by_one_line) {
+  mock_console c(80, 4);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::next_page);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("second");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("forth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("first\nsecond\nthird\nforth\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_multi_page_next_page_answer) {
+  mock_console c(80, 3);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::next_page);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("second");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("forth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(2, c.ask_for_continuation_count());
+
+  p.show("fifth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(2, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("first\nsecond\nthird\nforth\nfifth\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_multi_page_multiline_shows) {
+  mock_console c(80, 3);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::next_page);
+
+  p.show("first\nsecond");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("forth\nfifth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(2, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("first\nsecond\nthird\nforth\nfifth\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_multi_page_narrow_terminal) {
+  mock_console c(5, 3);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::next_page);
+
+  p.show("first" /*\n*/ "second");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("forth" /*\n*/ "fifth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(2, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("firstsecond\nthird\nforthfifth\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_multi_page_show_all_answer) {
+  mock_console c(80, 3);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::show_all);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("second");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("third");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("forth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  p.show("fifth");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("first\nsecond\nthird\nforth\nfifth\n", c.content());
+}
+
+JUST_TEST_CASE(test_pager_quit_answer) {
+  mock_console c(80, 3);
+  pager p(c);
+  c.set_continiation_answer(iface::console::user_answer::quit);
+
+  p.show("first");
+  JUST_ASSERT(p.new_line());
+  JUST_ASSERT_EQUAL(0, c.ask_for_continuation_count());
+
+  p.show("second");
+  JUST_ASSERT(!p.new_line());
+  JUST_ASSERT_EQUAL(1, c.ask_for_continuation_count());
+
+  JUST_ASSERT_EQUAL("first\nsecond\n", c.content());
+}


### PR DESCRIPTION
This should not be merged before the release.

### Pager

Contains support for pager for MDB commands which tend to have long outputs (ft and bt). Possible output on a very short terminal:
```cpp
(mdb) ft
int_<fib<40>::value>
+ fib<40> (TemplateInstantiation from <stdin>:2:31)
| + fib<39> (TemplateInstantiation from ./../fib.hpp:3:32)
| | + fib<38> (TemplateInstantiation from ./../fib.hpp:3:32)
| | | + fib<37> (TemplateInstantiation from ./../fib.hpp:3:32)
| | | | + fib<36> (TemplateInstantiation from ./../fib.hpp:3:32)
Next page (RETURN), Show all (a), Quit (q):
```

### Profiling

Experimental profiling support in MDB:
```cpp
(mdb) eval -profile int_<fib<5>::value>
Metaprogram started
(mdb) ft
int_<fib<5>::value>
+ [0.46ms, 79.48%] fib<5> (TemplateInstantiation from <stdin>:2:31)
| + [0.27ms, 45.86%] fib<4> (TemplateInstantiation from ./../fib.hpp:3:32)
| | + [0.20ms, 35.18%] fib<3> (TemplateInstantiation from ./../fib.hpp:3:32)
| | | + [0.12ms, 20.86%] fib<2> (TemplateInstantiation from ./../fib.hpp:3:32)
| | | | + [0.01ms, 1.55%] fib<0> (Memoization from ./../fib.hpp:3:50)
| | | | ` [0.01ms, 1.38%] fib<1> (Memoization from ./../fib.hpp:3:32)
| | | ` [0.01ms, 1.21%] fib<1> (Memoization from ./../fib.hpp:3:50)
| | ` [0.01ms, 0.86%] fib<2> (Memoization from ./../fib.hpp:3:50)
| ` [0.01ms, 1.03%] fib<3> (Memoization from ./../fib.hpp:3:50)
+ [0.05ms, 7.93%] int_<5> (TemplateInstantiation from <stdin>:2:48)
` [0.01ms, 0.86%] fib<5> (Memoization from <stdin>:2:31)
```

Not visible on the sample output, but the sub-trees are traversed from most-time-taken to least-time-taken, as opposed to the normal instantiation order determined by the compiler.

Docs and json support are coming in later PRs after the interface is finalized.

