### PR TITLE
Support arch linux by disabling TERMINFO support in LLVM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ elif [ "$(uname)" = "Darwin" ]
 then
   PLATFORM=osx
   PLATFORM_VERSION=$(sw_vers -productVersion)
-elif [ `cat /etc/lsb-release 2>/dev/null | grep DISTRIB_ID` = "DISTRIB_ID=Ubuntu" ]
+elif [ "`cat /etc/lsb-release 2>/dev/null | grep DISTRIB_ID`" = "DISTRIB_ID=Ubuntu" ]
 then
   PLATFORM=ubuntu
 elif [ -e /etc/debian_version ]

--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ echo "Platform: ${PLATFORM}"
 # Build Clang
 cd 3rd
   cd templight
-    mkdir build; cd build
+    mkdir -p build; cd build
       cmake ../llvm -DLIBCLANG_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release \
         && make clang libclang libclang_static templight -j${BUILD_THREADS}
     cd ..
@@ -90,7 +90,7 @@ then
   tools/clang_default_path --gcc=clang > lib/core/extra_sysinclude.hpp
 fi
 
-mkdir bin; cd bin
+mkdir -p bin; cd bin
   cmake .. \
     && make -j${BUILD_THREADS} \
     && make test \

--- a/build.sh
+++ b/build.sh
@@ -72,7 +72,10 @@ echo "Platform: ${PLATFORM}"
 cd 3rd
   cd templight
     mkdir -p build; cd build
-      cmake ../llvm -DLIBCLANG_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release \
+      cmake ../llvm \
+        -DLIBCLANG_BUILD_STATIC=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_ENABLE_TERMINFO=OFF \
         && make clang libclang libclang_static templight -j${BUILD_THREADS}
     cd ..
   cd ..

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,9 @@ then
 elif [ -e /etc/debian_version ]
 then
   PLATFORM=debian
+elif [ -e /etc/arch-release ]
+then
+  PLATFORM=arch
 elif [ `uname` = "FreeBSD" ]
 then
   PLATFORM=freebsd

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -e
+
 if [ ! -d cmake ]
 then
   echo "Please run this script from the root directory of the Metashell source code"

--- a/docs/getting_metashell/build.md
+++ b/docs/getting_metashell/build.md
@@ -23,7 +23,7 @@
     * `cd 3rd/templight`
     * `mkdir build`
     * `cd build`
-    * `cmake ../llvm -DLIBCLANG_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release`
+    * `cmake ../llvm -DLIBCLANG_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF`
     * `make clang libclang libclang_static templight`
 * Now compile Metashell. In the source directory run the following commands:
     * `mkdir bin`


### PR DESCRIPTION
The library linking issues are pretty chaotic around ncurses/termcap/terminfo, so it's probably best to disable them in our LLVM build at least for Linux.

We could narrow it down to only arch linux, but I'm not sure how many other non-tested distros are affected by this.

Fixes #38