### PR TITLE
Fix line wraps on Windows

### DIFF
--- a/lib/core/stdout_console.cpp
+++ b/lib/core/stdout_console.cpp
@@ -64,7 +64,7 @@ int stdout_console::width() const
     CONSOLE_SCREEN_BUFFER_INFO info;
 
     GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
-    return info.srWindow.Right - info.srWindow.Left + 1;
+    return info.srWindow.Right - info.srWindow.Left;
 #else
     struct winsize w;
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);


### PR DESCRIPTION
Apparently Windows doesn't like it when the line is
broken on the last column, and inserts an extra empty
line. This seriously broke the visuals of forwardtrace