### PR TITLE
Build fails with -DUSE_EDITLINE=true

### DIFF
--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -117,7 +117,8 @@ namespace
     {
       const std::string str(line);
 
-#if defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__ || defined USE_EDITLINE
+#if defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__ ||         \
+    defined USE_EDITLINE
       free(line);
 #else
       rl_free(line);

--- a/lib/readline/line_reader.cpp
+++ b/lib/readline/line_reader.cpp
@@ -117,7 +117,7 @@ namespace
     {
       const std::string str(line);
 
-#if defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
+#if defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__ || defined USE_EDITLINE
       free(line);
 #else
       rl_free(line);


### PR DESCRIPTION
Hi,

When compiling the master branch with `-DUSE_EDITLINE=true` flag, the compiler gives the following error:
```
[ 37%] Building CXX object lib/readline/CMakeFiles/metashell_readline_lib.dir/line_reader.cpp.o
/path/to/metashell/lib/readline/line_reader.cpp: In function ‘boost::optional<std::__cxx11::basic_string<char> > {anonymous}::read_next_line(const string&, metashell::command_processor_queue&)’:
/path/to/metashell/lib/readline/line_reader.cpp:123:19: error: ‘rl_free’ was not declared in this scope
       rl_free(line);
                   ^
```

libedit does not have `rl_free()` function, so use `free()` when `USE_EDITLINE` is enabled.

Tested environments
* Arch Linux x86_64
* GCC 5.3.0
* libedit 20150325-3.1