### PR TITLE
Turn off -Werror in travis for OS X

### DIFF
--- a/tools/travis/osx.sh
+++ b/tools/travis/osx.sh
@@ -27,7 +27,7 @@ cd ../..
 
 # Test the code
 
-BUILD_THREADS=2 CXXFLAGS=-Werror NO_TEMPLIGHT=1 ./build.sh
+BUILD_THREADS=2 NO_TEMPLIGHT=1 ./build.sh
 
 # Test that the documentation about the built-in pragmas and mdb commands is up to date
 


### PR DESCRIPTION
This happens since the gcc5 package was updated to 5.3.

I have no clue why this compiler doesn't silence warnings from headers included with -isystem. I'll look into it later. For now I turned off -Werror on OS X.