### PR TITLE
Update to newest osx_image and remove workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 sudo: required
 dist: trusty
+osx_image: xcode10.1
 os:
   - linux
   - osx

--- a/tools/travis/osx.sh
+++ b/tools/travis/osx.sh
@@ -2,15 +2,7 @@
 
 set -ex
 
-# Workaround for some faulty travis image
-# https://github.com/travis-ci/travis-ci/issues/9640
-sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"
-
 brew update >/dev/null
-
-# Oclint installs something under /usr/local/include/c++ which
-# conflicts with files installed by gcc
-brew cask uninstall oclint
 
 brew install p7zip
 


### PR DESCRIPTION
At the moment this is the newest osx_image according to this: https://docs.travis-ci.com/user/reference/osx/