### PR TITLE
Github actions MacOS CI 

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -13,4 +13,4 @@ jobs:
 
     - name: Build
       shell: bash
-      run: BUILD_THREADS=3 ./build.sh
+      run: NO_INSTALLER=1 BUILD_THREADS=3 ./build.sh

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,16 @@
+name: CI macOS
+
+on: [push, pull_request]
+
+jobs:
+  run:
+
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build
+      shell: bash
+      run: BUILD_THREADS=3 ./build.sh

--- a/3rd/boost/wave/include/boost/wave/util/cpp_macromap.hpp
+++ b/3rd/boost/wave/include/boost/wave/util/cpp_macromap.hpp
@@ -1869,24 +1869,12 @@ macromap<ContextT>::resolve_has_include(IteratorT &first,
     ContainerT result;
     bool is_quoted_filename;
     bool is_system;
+    IteratorT start = first;
 
-    // to simplify the parser we check for the trailing right paren first
-    // scan from the beginning because unput_queue_iterator is Forward
-    IteratorT end_find_it = first;
-    ++end_find_it;
-    IteratorT rparen_it = first;
-    while (end_find_it != last) {
-        ++end_find_it;
-        ++rparen_it;
-    }
-
-    boost::spirit::classic::parse_info<IteratorT> hit(first);
-    if ((rparen_it != first) && (T_RIGHTPAREN == *rparen_it)) {
-        IteratorT start = first;
-        hit = has_include_grammar_gen<typename ContextT::lexer_type>::
-            parse_operator_has_include(start, rparen_it, result, is_quoted_filename, is_system);
-    }
-
+    boost::spirit::classic::parse_info<IteratorT> hit = 
+        has_include_grammar_gen<typename ContextT::lexer_type>::
+        parse_operator_has_include(start, last, result, is_quoted_filename, is_system);
+   
     if (!hit.hit) {
         string_type msg ("__has_include(): ");
         msg = msg + util::impl::as_string<string_type>(first, last);
@@ -1897,7 +1885,7 @@ macromap<ContextT>::resolve_has_include(IteratorT &first,
         pending.push_back(token_type(T_INTLIT, "0", main_pos));
     }
     else {
-        impl::assign_iterator<IteratorT>::do_(first, last);
+        impl::assign_iterator<IteratorT>::do_(first, hit.stop);
 
         // insert a token, which reflects the outcome
         pending.push_back(

--- a/lib/engine/wave/src/context.cpp
+++ b/lib/engine/wave/src/context.cpp
@@ -136,6 +136,7 @@ namespace metashell
         {
           boost::wave::language_support result =
               language_support(cfg_.config.standard);
+          result = boost::wave::enable_has_include(result);
           if (cfg_.long_long)
           {
             result = boost::wave::enable_long_long(result);

--- a/lib/system_test/include/metashell/system_test/read_only_path.hpp
+++ b/lib/system_test/include/metashell/system_test/read_only_path.hpp
@@ -33,7 +33,7 @@ namespace metashell
       boost::filesystem::path path() const;
 
     private:
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
       just::temp::directory _temp;
 #endif
     };

--- a/lib/system_test/src/read_only_path.cpp
+++ b/lib/system_test/src/read_only_path.cpp
@@ -57,6 +57,9 @@ namespace metashell
       {
         throw std::runtime_error("Error creating " + p.string());
       }
+#elif defined(__APPLE__)
+      // make the directory readable and executable for all
+      chmod(_temp.path().c_str(), 0555);
 #endif
     }
 
@@ -64,6 +67,8 @@ namespace metashell
     {
 #ifdef _WIN32
       return boost::filesystem::path(_temp.path()) / subpath();
+#elif defined(__APPLE__)
+      return boost::filesystem::path(_temp.path());
 #else
       return "/proc";
 #endif


### PR DESCRIPTION
Had to fix two test failures:
* A bug in boost wave prevented parsing some system headers due to a bug in the `__has_include` grammar. For this I cherry picked some parts of a boost::wave fix: https://github.com/boostorg/wave/pull/144 (not yet released in an official boost.wave release). I also enabled `__has_include` parsing by default. Normally it is only enabled on C++17 and above.
* Another test failure was caused by `/proc` being used as read-only directory. `/proc` doesn't exist on macOS, so a simple `chmod` based approach was used.